### PR TITLE
feat: catalogue sync orchestration and infrastructure adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-POSTGRES_DB=nis_export_update
+POSTGRES_DB=data_catalogue_upload
 POSTGRES_PORT=5432

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# nis-export-update
+# data-catalogue-upload
+
+Scheduled sync job that reads biobank export and related APIs (sequencing, WSI, radiology) and upserts records into the data catalogue.
+
+## Database
+
+Copy [`.env.example`](.env.example) to `.env` and set `POSTGRES_PORT` if the default port is in use. Start PostgreSQL:
+
+```bash
+docker compose -f compose.prod.yml up -d
+```
+
+Apply Alembic migrations (place `.env` in the **project root**; `src/migrations/env.py` loads it before connecting):
+
+```bash
+cd src && uv run alembic -c alembic.ini upgrade head
+```
+
+The ORM defines two application tables, both created by the initial migration: `sync_run` and `sync_state` (plus `alembic_version` for migration history).

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,7 +1,7 @@
 services:
   db:
     image: postgres:16
-    container_name: nis-export-update-db
+    container_name: data-catalogue-upload-db
     restart: unless-stopped
 
     env_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "requests",
     "sqlalchemy",
     "psycopg2-binary",
     "python-dotenv>=1.2.2",
@@ -15,10 +16,11 @@ dev = [
     "pytest",
     "ruff",
     "mypy",
+    "types-requests",
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"src/migrations/env.py" = ["E402"] # load_dotenv before importing infrastructure.session
+"src/migrations/env.py" = ["E402"] # load_dotenv must run before importing infrastructure (session builds engine at import)
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/application/__init__.py
+++ b/src/application/__init__.py
@@ -1,0 +1,8 @@
+from application.sync_planner import FingerprintSyncPlanner
+from application.sync_service import CatalogueSyncService, RunSummary
+
+__all__ = [
+    "CatalogueSyncService",
+    "FingerprintSyncPlanner",
+    "RunSummary",
+]

--- a/src/application/sync_planner.py
+++ b/src/application/sync_planner.py
@@ -1,0 +1,48 @@
+from domain.models import (
+    CatalogueOperation,
+    PatientAggregate,
+    PlannedOperation,
+    SyncState,
+)
+
+
+class FingerprintSyncPlanner:
+    def plan_patient(
+        self, patient: PatientAggregate, current: SyncState | None
+    ) -> PlannedOperation:
+        if not patient.is_upload_eligible():
+            return PlannedOperation(
+                entity_type="patient",
+                entity_key=patient.patient_id,
+                operation=CatalogueOperation.SKIP,
+                payload=None,
+                source_fingerprint=None,
+            )
+
+        fingerprint = patient.source_fingerprint()
+        payload = {"patient": patient}
+        if current is None or current.is_deleted:
+            return PlannedOperation(
+                entity_type="patient",
+                entity_key=patient.patient_id,
+                operation=CatalogueOperation.CREATE,
+                payload=payload,
+                source_fingerprint=fingerprint,
+            )
+
+        if current.source_fingerprint != fingerprint:
+            return PlannedOperation(
+                entity_type="patient",
+                entity_key=patient.patient_id,
+                operation=CatalogueOperation.UPDATE,
+                payload=payload,
+                source_fingerprint=fingerprint,
+            )
+
+        return PlannedOperation(
+            entity_type="patient",
+            entity_key=patient.patient_id,
+            operation=CatalogueOperation.SKIP,
+            payload=None,
+            source_fingerprint=fingerprint,
+        )

--- a/src/application/sync_service.py
+++ b/src/application/sync_service.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import uuid
+
+from application.interfaces.ports import (
+    CatalogueGateway,
+    SourceDataGateway,
+    SyncPlanner,
+    SyncStateRepository,
+)
+from domain.models import (
+    CatalogueOperation,
+    PatientAggregate,
+    RadiologyData,
+    Sample,
+    SequencingData,
+    SyncState,
+    SyncStatus,
+    WsiData,
+    now_utc,
+)
+
+
+@dataclass
+class RunSummary:
+    run_id: str
+    scanned: int = 0
+    changed: int = 0
+    uploaded: int = 0
+    deleted: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+class CatalogueSyncService:
+    def __init__(
+        self,
+        source_gateway: SourceDataGateway,
+        catalogue_gateway: CatalogueGateway,
+        state_repository: SyncStateRepository,
+        planner: SyncPlanner,
+    ) -> None:
+        self.source_gateway = source_gateway
+        self.catalogue_gateway = catalogue_gateway
+        self.state_repository = state_repository
+        self.planner = planner
+
+    def run_catalogue_sync(self) -> RunSummary:
+        run_id = str(uuid.uuid4())
+        summary = RunSummary(run_id=run_id)
+        raw_patients = self.source_gateway.fetch_patients()
+
+        seen_keys: set[str] = set()
+        for raw_patient in raw_patients:
+            patient = self._build_patient_aggregate(raw_patient)
+            summary.scanned += 1
+            seen_keys.add(patient.patient_id)
+
+            existing = self.state_repository.get("patient", patient.patient_id)
+            operation = self.planner.plan_patient(patient, existing)
+            if operation.operation == CatalogueOperation.SKIP:
+                summary.skipped += 1
+                continue
+
+            summary.changed += 1
+            try:
+                if operation.operation in (
+                    CatalogueOperation.CREATE,
+                    CatalogueOperation.UPDATE,
+                ):
+                    remote_id = self.catalogue_gateway.upsert_patient(patient)
+                    summary.uploaded += 1
+                    self.state_repository.save(
+                        SyncState(
+                            entity_type="patient",
+                            entity_key=patient.patient_id,
+                            source_fingerprint=operation.source_fingerprint or "",
+                            catalogue_remote_id=remote_id,
+                            status=SyncStatus.SYNCED,
+                            is_deleted=False,
+                            last_seen_at=now_utc(),
+                            last_synced_at=now_utc(),
+                            last_error=None,
+                            run_id=run_id,
+                        )
+                    )
+            except Exception as exc:  # prototype: keep run moving
+                summary.failed += 1
+                self.state_repository.save(
+                    SyncState(
+                        entity_type="patient",
+                        entity_key=patient.patient_id,
+                        source_fingerprint=operation.source_fingerprint or "",
+                        catalogue_remote_id=existing.catalogue_remote_id
+                        if existing
+                        else None,
+                        status=SyncStatus.FAILED,
+                        is_deleted=False,
+                        last_seen_at=now_utc(),
+                        last_synced_at=existing.last_synced_at if existing else None,
+                        last_error=str(exc),
+                        run_id=run_id,
+                    )
+                )
+
+        missing_states = self.state_repository.mark_missing_as_deleted(
+            entity_type="patient", seen_keys=seen_keys, run_id=run_id
+        )
+        for state in missing_states:
+            try:
+                self.catalogue_gateway.delete_patient(
+                    state.entity_key, state.catalogue_remote_id
+                )
+                summary.deleted += 1
+            except Exception:
+                summary.failed += 1
+
+        return summary
+
+    def _build_patient_aggregate(self, raw_patient: dict) -> PatientAggregate:
+        samples: list[Sample] = []
+        for raw_sample in raw_patient.get("samples", []):
+            predictive_number = raw_sample.get("predictive_number")
+            bioptic_number = raw_sample.get("bioptic_number")
+
+            sequencing = None
+            if predictive_number:
+                sequencing_payload = self.source_gateway.fetch_sequencing(
+                    predictive_number
+                )
+                if sequencing_payload:
+                    sequencing = SequencingData(
+                        predictive_number=predictive_number,
+                        source_id=str(sequencing_payload.get("id", predictive_number)),
+                        payload=sequencing_payload,
+                    )
+
+            wsi = None
+            if bioptic_number:
+                wsi_payload = self.source_gateway.fetch_wsi(bioptic_number)
+                if wsi_payload:
+                    wsi = WsiData(
+                        bioptic_number=bioptic_number,
+                        source_id=str(wsi_payload.get("id", bioptic_number)),
+                        payload=wsi_payload,
+                    )
+
+            samples.append(
+                Sample(
+                    sample_id=str(raw_sample["sample_id"]),
+                    predictive_number=predictive_number,
+                    bioptic_number=bioptic_number,
+                    payload=raw_sample,
+                    sequencing=sequencing,
+                    wsi=wsi,
+                )
+            )
+
+        accession_numbers = [
+            str(value) for value in raw_patient.get("accession_numbers", [])
+        ]
+        radiology_payloads = self.source_gateway.fetch_radiology(accession_numbers)
+        radiology = [
+            RadiologyData(
+                accession_number=str(item["accession_number"]),
+                source_id=str(item.get("id", item["accession_number"])),
+                payload=item,
+            )
+            for item in radiology_payloads
+        ]
+
+        return PatientAggregate(
+            patient_id=str(raw_patient["patient_id"]),
+            accession_numbers=accession_numbers,
+            samples=samples,
+            payload=raw_patient,
+            radiology=radiology,
+        )

--- a/src/infrastructure/__init__.py
+++ b/src/infrastructure/__init__.py
@@ -1,0 +1,24 @@
+from infrastructure.api.clients import (
+    ApiClient,
+    HttpCatalogueGateway,
+    HttpSourceDataGateway,
+    build_catalogue_gateway_from_env,
+    build_source_gateway_from_env,
+)
+from infrastructure.db.models import Base
+from infrastructure.db.session import SessionLocal, engine
+from infrastructure.db.sync_run_repository import SyncRunRepository
+from infrastructure.db.sync_state_repository import SyncStateRepository
+
+__all__ = [
+    "ApiClient",
+    "Base",
+    "HttpCatalogueGateway",
+    "HttpSourceDataGateway",
+    "SessionLocal",
+    "SyncRunRepository",
+    "SyncStateRepository",
+    "build_catalogue_gateway_from_env",
+    "build_source_gateway_from_env",
+    "engine",
+]

--- a/src/infrastructure/api/clients.py
+++ b/src/infrastructure/api/clients.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+import requests
+
+from domain.models import PatientAggregate
+
+
+class ApiClient:
+    def __init__(self, base_url: str, timeout_seconds: int = 30) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+
+    def get(self, path: str, params: dict | None = None) -> Any:
+        response = requests.get(
+            f"{self.base_url}/{path.lstrip('/')}",
+            params=params,
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def post(self, path: str, payload: dict) -> Any:
+        response = requests.post(
+            f"{self.base_url}/{path.lstrip('/')}",
+            json=payload,
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def delete(self, path: str) -> None:
+        response = requests.delete(
+            f"{self.base_url}/{path.lstrip('/')}",
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+
+
+class HttpSourceDataGateway:
+    def __init__(
+        self,
+        biobank_client: ApiClient,
+        radiology_client: ApiClient,
+        sequencing_client: ApiClient,
+        wsi_client: ApiClient,
+    ) -> None:
+        self.biobank_client = biobank_client
+        self.radiology_client = radiology_client
+        self.sequencing_client = sequencing_client
+        self.wsi_client = wsi_client
+
+    def fetch_patients(self) -> list[dict[str, Any]]:
+        return cast(list[dict[str, Any]], self.biobank_client.get("/patients"))
+
+    def fetch_radiology(self, accession_numbers: list[str]) -> list[dict[str, Any]]:
+        if not accession_numbers:
+            return []
+        return cast(
+            list[dict[str, Any]],
+            self.radiology_client.get(
+                "/radiology",
+                params={"accession_numbers": ",".join(accession_numbers)},
+            ),
+        )
+
+    def fetch_sequencing(self, predictive_number: str) -> dict[str, Any] | None:
+        return cast(
+            dict[str, Any] | None,
+            self.sequencing_client.get(
+                "/sequencing",
+                params={"predictive_number": predictive_number},
+            ),
+        )
+
+    def fetch_wsi(self, bioptic_number: str) -> dict[str, Any] | None:
+        return cast(
+            dict[str, Any] | None,
+            self.wsi_client.get("/slides", params={"bioptic_number": bioptic_number}),
+        )
+
+
+class HttpCatalogueGateway:
+    def __init__(self, catalogue_client: ApiClient) -> None:
+        self.catalogue_client = catalogue_client
+
+    def upsert_patient(self, patient: PatientAggregate) -> str:
+        response = self.catalogue_client.post(
+            "/patients/upsert",
+            payload={
+                "external_id": patient.patient_id,
+                "accession_numbers": patient.accession_numbers,
+                "samples": [
+                    {
+                        "sample_id": sample.sample_id,
+                        "predictive_number": sample.predictive_number,
+                        "bioptic_number": sample.bioptic_number,
+                        "sequencing": sample.sequencing.payload
+                        if sample.sequencing
+                        else None,
+                        "wsi": sample.wsi.payload if sample.wsi else None,
+                    }
+                    for sample in patient.samples
+                ],
+                "radiology": [entry.payload for entry in patient.radiology],
+                "payload": patient.payload,
+            },
+        )
+        remote_id = response.get("id") or response.get("patient_id")
+        if not remote_id:
+            raise RuntimeError("Catalogue upsert response does not include id")
+        return str(remote_id)
+
+    def delete_patient(self, entity_key: str, remote_id: str | None) -> None:
+        target_id = remote_id or entity_key
+        self.catalogue_client.delete(f"/patients/{target_id}")
+
+
+def build_source_gateway_from_env() -> HttpSourceDataGateway:
+    return HttpSourceDataGateway(
+        biobank_client=ApiClient(os.environ["BIOBANK_API_URL"]),
+        radiology_client=ApiClient(os.environ["RADIOLOGY_API_URL"]),
+        sequencing_client=ApiClient(os.environ["SEQUENCING_API_URL"]),
+        wsi_client=ApiClient(os.environ["WSI_API_URL"]),
+    )
+
+
+def build_catalogue_gateway_from_env() -> HttpCatalogueGateway:
+    return HttpCatalogueGateway(
+        catalogue_client=ApiClient(os.environ["CATALOGUE_API_URL"])
+    )

--- a/src/infrastructure/db/sync_run_repository.py
+++ b/src/infrastructure/db/sync_run_repository.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from application.sync_service import RunSummary
+from infrastructure.db.models import SyncRunORM
+
+
+class SyncRunRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def start(self, run_id: str) -> None:
+        self.session.add(SyncRunORM(id=run_id))
+        self.session.commit()
+
+    def finish(self, summary: RunSummary) -> None:
+        run = self.session.get(SyncRunORM, summary.run_id)
+        if run is None:
+            run = SyncRunORM(id=summary.run_id)
+            self.session.add(run)
+        run.finished_at = datetime.now(timezone.utc)
+        run.scanned_count = summary.scanned
+        run.changed_count = summary.changed
+        run.uploaded_count = summary.uploaded
+        run.deleted_count = summary.deleted
+        run.skipped_count = summary.skipped
+        run.failed_count = summary.failed
+        self.session.commit()

--- a/src/infrastructure/db/sync_state_repository.py
+++ b/src/infrastructure/db/sync_state_repository.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from domain.models import SyncState, SyncStatus
+from infrastructure.db.models import SyncStateORM, SyncStatusDB
+
+
+def to_domain(orm: SyncStateORM) -> SyncState:
+    return SyncState(
+        entity_type=orm.entity_type,
+        entity_key=orm.entity_key,
+        source_fingerprint=orm.source_fingerprint,
+        catalogue_remote_id=orm.catalogue_remote_id,
+        status=SyncStatus(orm.status.value),
+        is_deleted=orm.is_deleted,
+        last_seen_at=orm.last_seen_at,
+        last_synced_at=orm.last_synced_at,
+        last_error=orm.last_error,
+        run_id=orm.run_id,
+    )
+
+
+class SyncStateRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get(self, entity_type: str, entity_key: str) -> SyncState | None:
+        stmt = (
+            select(SyncStateORM)
+            .where(SyncStateORM.entity_type == entity_type)
+            .where(SyncStateORM.entity_key == entity_key)
+            .order_by(SyncStateORM.id.desc())
+            .limit(1)
+        )
+        orm = self.session.execute(stmt).scalar_one_or_none()
+        return to_domain(orm) if orm else None
+
+    def save(self, state: SyncState) -> None:
+        stmt = (
+            select(SyncStateORM)
+            .where(SyncStateORM.entity_type == state.entity_type)
+            .where(SyncStateORM.entity_key == state.entity_key)
+            .order_by(SyncStateORM.id.desc())
+            .limit(1)
+        )
+        existing = self.session.execute(stmt).scalar_one_or_none()
+        if existing:
+            existing.source_fingerprint = state.source_fingerprint
+            existing.catalogue_remote_id = state.catalogue_remote_id
+            existing.status = SyncStatusDB(state.status.value)
+            existing.is_deleted = state.is_deleted
+            existing.last_seen_at = state.last_seen_at
+            existing.last_synced_at = state.last_synced_at
+            existing.last_error = state.last_error
+            existing.run_id = state.run_id
+        else:
+            self.session.add(
+                SyncStateORM(
+                    entity_type=state.entity_type,
+                    entity_key=state.entity_key,
+                    source_fingerprint=state.source_fingerprint,
+                    catalogue_remote_id=state.catalogue_remote_id,
+                    status=SyncStatusDB(state.status.value),
+                    is_deleted=state.is_deleted,
+                    last_seen_at=state.last_seen_at,
+                    last_synced_at=state.last_synced_at,
+                    last_error=state.last_error,
+                    run_id=state.run_id,
+                )
+            )
+        self.session.commit()
+
+    def mark_missing_as_deleted(
+        self, entity_type: str, seen_keys: set[str], run_id: str
+    ) -> list[SyncState]:
+        stmt = select(SyncStateORM).where(SyncStateORM.entity_type == entity_type)
+        rows = self.session.execute(stmt).scalars().all()
+        missing: list[SyncState] = []
+        now = datetime.now(timezone.utc)
+        for row in rows:
+            if row.entity_key in seen_keys or row.is_deleted:
+                continue
+            row.is_deleted = True
+            row.status = SyncStatusDB.DELETED
+            row.last_seen_at = now
+            row.last_synced_at = now
+            row.last_error = None
+            row.run_id = run_id
+            missing.append(to_domain(row))
+        self.session.commit()
+        return missing

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import os
+from dotenv import load_dotenv
+
+from application import CatalogueSyncService, FingerprintSyncPlanner
+from infrastructure import (
+    Base,
+    SessionLocal,
+    SyncRunRepository,
+    SyncStateRepository,
+    build_catalogue_gateway_from_env,
+    build_source_gateway_from_env,
+    engine,
+)
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def main() -> int:
+    load_dotenv()
+    _require_env("BIOBANK_API_URL")
+    _require_env("RADIOLOGY_API_URL")
+    _require_env("SEQUENCING_API_URL")
+    _require_env("WSI_API_URL")
+    _require_env("CATALOGUE_API_URL")
+
+    Base.metadata.create_all(bind=engine)
+    with SessionLocal() as session:
+        service = CatalogueSyncService(
+            source_gateway=build_source_gateway_from_env(),
+            catalogue_gateway=build_catalogue_gateway_from_env(),
+            state_repository=SyncStateRepository(session),
+            planner=FingerprintSyncPlanner(),
+        )
+
+        summary = service.run_catalogue_sync()
+        SyncRunRepository(session).finish(summary)
+
+    print(json.dumps(summary.__dict__, indent=2, sort_keys=True))
+    return 0 if summary.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,104 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -36,6 +134,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
+    { name = "requests" },
     { name = "sqlalchemy" },
 ]
 
@@ -45,12 +144,14 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "psycopg2-binary" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "requests" },
     { name = "sqlalchemy" },
 ]
 
@@ -60,6 +161,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-requests" },
 ]
 
 [[package]]
@@ -107,6 +209,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
 ]
 
 [[package]]
@@ -450,6 +561,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
@@ -528,10 +654,31 @@ wheels = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.33.0.20260503"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b8/57e94268c0d82ac3eaa2fc35aa8ca7bbc2542f726b67dcf90b0b00a3b14d/types_requests-2.33.0.20260503.tar.gz", hash = "sha256:9721b2d9dbee7131f2fb39f20f0ebb1999c18cef4b512c9a7932f3722de7c5f4", size = 23931, upload-time = "2026-05-03T05:20:08.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/82/959113a6351f3ca046cd0a8cd2cee071d7ea47473560557a01eeae9a6fe2/types_requests-2.33.0.20260503-py3-none-any.whl", hash = "sha256:02aaa7e3577a13471715bb1bddb693cc985ea514f754b503bf033e6a09a3e528", size = 20736, upload-time = "2026-05-03T05:20:07.858Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## Summary

- Implements `CatalogueSyncService` + fingerprint-based planner.
- Adds HTTP clients for biobank/radiology/sequencing/WSI/catalogue APIs.
- Implements sync state and sync run repositories; wires `main` for cron execution.
- Aligns README, compose container name, `.env.example`, and tooling (ruff/mypy/stubs) for CI.

## Issue

Fixes #8

## Depends on

- **Stacked PR:** target branch is `feat/domain-sync-schema-and-ports` until the domain/schema PR merges. After #7 is merged to `master`, rebase/retarget this PR to `master` if needed.
- **CI:** full pipeline should pass on the PR branch.
