### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/BBMRI-cz/data-catalogue-upload/security/code-scanning/1](https://github.com/BBMRI-cz/data-catalogue-upload/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (recommended here since there is a single job and all steps share the same needs). Use least privilege: `contents: read` is sufficient for `actions/checkout` and running CI checks. This does not change functionality; it only constrains token scope.

**File/region to change**
- `.github/workflows/ci.yml`
- Insert `permissions:` between the `on:` trigger section and `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
