### PR TITLE
feat(domain): define biobank patient/sample/clinical domain model (#34)

### DIFF
--- a/apps/biobank_api/src/biobank_api/domain/cleaning.py
+++ b/apps/biobank_api/src/biobank_api/domain/cleaning.py
@@ -1,0 +1,168 @@
+"""Pure cleaning/normalization of raw biobank XML values.
+
+Every function here turns a raw string (an XML attribute value or element text, exactly
+as extracted from the export) into a typed/cleaned domain value. No I/O, no framework
+imports. These are the building blocks the model ``from_raw`` factories use and the
+single place the documented value quirks (report §6.x) are handled:
+
+* ``<patient month>`` is ISO 8601 ``gMonth`` (``--MM``)            -> :func:`parse_month`
+* dates are an ``xs:date`` | ``xs:dateTime`` union                 -> :func:`parse_temporal`
+* ``biopsy`` / ``predictive_number`` use ``"-"`` to mean "n/a"     -> :func:`dash_to_none`
+* STS ``sampleId`` carries an ``&amp;`` prefix (decoded to ``&``)  -> :func:`clean_sample_id`
+
+Source of truth: ``docs/patient-data-report.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from biobank_api.domain.enums import Retrieved, Sex
+
+
+def clean_text(raw: str | None) -> str | None:
+    """Strip surrounding whitespace; treat empty/whitespace-only as ``None``.
+
+    ``"  MOU "`` -> ``"MOU"``; ``""`` / ``None`` -> ``None``.
+    """
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    return stripped or None
+
+
+def clean_accessions(values: list[str] | None) -> list[str]:
+    """Strip and drop empty entries from ``<AccessionNumbers>/<Number>`` values.
+
+    ``[" RDG2005041156 ", ""]`` -> ``["RDG2005041156"]``.
+    """
+    if not values:
+        return []
+    return [cleaned for cleaned in (clean_text(value) for value in values) if cleaned]
+
+
+def clean_code(raw: str | None) -> str | None:
+    """Clean a code-like value (``diagnosis`` / ``morphology`` / ``pTNM``).
+
+    Strips whitespace and preserves case; empty -> ``None``. ``" C504 "`` -> ``"C504"``.
+    ICD-10 codes are kept dot-less exactly as exported (report §6.6).
+    """
+    return clean_text(raw)
+
+
+def clean_sample_id(raw: str | None) -> str | None:
+    """Strip a ``sampleId`` value; empty -> ``None``.
+
+    lxml already decodes the STS ``&amp;`` entity, so the input here is already
+    ``"&:2022:118485"`` (report §6.3.1 / §7). ``" BBM:2023:181:1 "`` -> ``"BBM:2023:181:1"``.
+    """
+    return clean_text(raw)
+
+
+def dash_to_none(raw: str | None) -> str | None:
+    """Map the ``"-"`` sentinel (and empty) to ``None``, else the stripped value.
+
+    Used for ``biopsy`` / ``predictive_number`` where ``"-"`` means "not applicable"
+    (report §6.3.1 / §7). ``"-"`` -> ``None``; ``"2023/2872-1"`` -> ``"2023/2872-1"``.
+    """
+    cleaned = clean_text(raw)
+    if cleaned == "-":
+        return None
+    return cleaned
+
+
+def parse_consent(raw: str | None) -> bool | None:
+    """Parse the ``<patient consent>`` boolean (report §6.1).
+
+    ``"true"`` -> ``True``; ``"false"`` -> ``False`` (case-insensitive); empty -> ``None``.
+    Raises ``ValueError`` on any other non-empty value.
+    """
+    cleaned = clean_text(raw)
+    if cleaned is None:
+        return None
+    lowered = cleaned.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    raise ValueError(f"invalid consent value: {raw!r}")
+
+
+def parse_sex(raw: str | None) -> Sex | None:
+    """Parse the ``<patient sex>`` attribute into :class:`Sex` (report §6.1).
+
+    ``"female"`` -> ``Sex.FEMALE``; empty -> ``None``. Raises ``ValueError`` on an
+    unrecognized non-empty value.
+    """
+    cleaned = clean_text(raw)
+    if cleaned is None:
+        return None
+    try:
+        return Sex(cleaned.lower())
+    except ValueError as exc:
+        raise ValueError(f"invalid sex value: {raw!r}") from exc
+
+
+def parse_retrieved(raw: str | None) -> Retrieved | None:
+    """Parse the ``<retrieved>`` element into :class:`Retrieved` (report §6.12).
+
+    ``"operational"`` -> ``Retrieved.OPERATIONAL``; empty -> ``None``. Raises
+    ``ValueError`` on an unrecognized non-empty value.
+    """
+    cleaned = clean_text(raw)
+    if cleaned is None:
+        return None
+    try:
+        return Retrieved(cleaned.lower())
+    except ValueError as exc:
+        raise ValueError(f"invalid retrieved value: {raw!r}") from exc
+
+
+def parse_int(raw: str | None) -> int | None:
+    """Parse an integer-valued field (e.g. ``number``, ``<samplesNo>``); empty -> ``None``.
+
+    ``" 524 "`` -> ``524``. Raises ``ValueError`` on a non-integer non-empty value.
+    """
+    cleaned = clean_text(raw)
+    if cleaned is None:
+        return None
+    return int(cleaned)
+
+
+def parse_year(raw: str | None) -> int | None:
+    """Parse an ``xs:gYear`` value (``<patient year>``, sample ``year``); empty -> ``None``.
+
+    ``"2023"`` -> ``2023`` (report §6.1). Raises ``ValueError`` on a non-numeric value.
+    """
+    return parse_int(raw)
+
+
+def parse_month(raw: str | None) -> int | None:
+    """Parse an ``xs:gMonth`` value (``<patient month>``) into a month number.
+
+    ISO 8601 ``gMonth`` form ``--MM`` (report §6.1): ``"--07"`` -> ``7``; empty -> ``None``.
+    The leading ``--`` is optional here so a bare ``"7"`` also parses. Range validity
+    (1-12) is enforced by the owning model's invariants.
+    """
+    cleaned = clean_text(raw)
+    if cleaned is None:
+        return None
+    if cleaned.startswith("--"):
+        cleaned = cleaned[2:]
+    return int(cleaned)
+
+
+def parse_temporal(raw: str | None) -> date | datetime | None:
+    """Parse an ``xs:date`` | ``xs:dateTime`` union value; empty -> ``None``.
+
+    Returns a :class:`datetime.datetime` when a time component is present (``"T"``),
+    otherwise a :class:`datetime.date` (report §6.10–§6.11):
+    ``"2023-03-24T11:15:00"`` -> ``datetime(2023, 3, 24, 11, 15)``;
+    ``"2023-03-24"`` -> ``date(2023, 3, 24)``.
+    """
+    cleaned = clean_text(raw)
+    if cleaned is None:
+        return None
+    if "T" in cleaned:
+        return datetime.fromisoformat(cleaned)
+    return date.fromisoformat(cleaned)

--- a/apps/biobank_api/src/biobank_api/domain/enums.py
+++ b/apps/biobank_api/src/biobank_api/domain/enums.py
@@ -1,0 +1,36 @@
+"""Enumerations for closed-vocabulary biobank XML values.
+
+Source of truth: ``docs/patient-data-report.md`` (the MOU biobank XML export, namespace
+``http://www.bbmri.cz/schemas/biobank/data``, schema ``exportNIS.xsd``). See report
+§5/§6.1 for ``sex`` and §6.12 for ``retrieved``.
+
+Kept at the ``domain`` root (not under ``domain/models``) so the low-level
+:mod:`biobank_api.domain.cleaning` helpers can depend on it without importing the models
+package — which would otherwise create an import cycle.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Sex(Enum):
+    """Patient sex (``<patient sex>`` attribute; report §6.1).
+
+    Maps to FAIR Genomes ``Personal.gender_at_birth`` / ``genotypic sex``.
+    """
+
+    MALE = "male"
+    FEMALE = "female"
+
+
+class Retrieved(Enum):
+    """Collection context of a sample (``<retrieved>`` element; report §6.12).
+
+    ``operational`` = taken during an active surgical/clinical procedure;
+    ``unknown`` = collection context not recorded (always ``unknown`` for STS
+    diagnostic specimens).
+    """
+
+    OPERATIONAL = "operational"
+    UNKNOWN = "unknown"

--- a/apps/biobank_api/src/biobank_api/domain/models/__init__.py
+++ b/apps/biobank_api/src/biobank_api/domain/models/__init__.py
@@ -1,3 +1,32 @@
-from biobank_api.domain.models.patient import Patient, Sample
+from biobank_api.domain.enums import Retrieved, Sex
+from biobank_api.domain.models.material_types import (
+    DIAGNOSIS_MATERIAL_TYPES,
+    GENOME_MATERIAL_TYPES,
+    SERUM_MATERIAL_TYPES,
+    TISSUE_MATERIAL_TYPES,
+    material_type_label,
+)
+from biobank_api.domain.models.patient import Patient
+from biobank_api.domain.models.sample import (
+    DiagnosticSpecimen,
+    GenomeSample,
+    Sample,
+    SerumSample,
+    TissueSample,
+)
 
-__all__ = ["Patient", "Sample"]
+__all__ = [
+    "DIAGNOSIS_MATERIAL_TYPES",
+    "GENOME_MATERIAL_TYPES",
+    "SERUM_MATERIAL_TYPES",
+    "TISSUE_MATERIAL_TYPES",
+    "DiagnosticSpecimen",
+    "GenomeSample",
+    "Patient",
+    "Retrieved",
+    "Sample",
+    "SerumSample",
+    "Sex",
+    "TissueSample",
+    "material_type_label",
+]

--- a/apps/biobank_api/src/biobank_api/domain/models/material_types.py
+++ b/apps/biobank_api/src/biobank_api/domain/models/material_types.py
@@ -1,0 +1,72 @@
+"""Material-type code lookups for biobank samples.
+
+The ``<materialType>`` element carries a short code whose meaning depends on the
+enclosing element (``<tissue>`` / ``<serum>`` / ``<genome>`` / ``<diagnosisMaterial>``).
+The tables below reproduce ``docs/patient-data-report.md`` §6.5 (full lookup) so the
+meaning of a code such as ``53`` / ``SD`` / ``PK`` is discoverable from the model.
+
+Codes are intentionally *not* hard-validated by the domain models (new codes may appear
+in future exports); these maps are reference data plus the :func:`material_type_label`
+convenience lookup. The pathological/storage semantics encoded here are what FAIR
+Genomes ``Material.pathological_state`` / ``Material.biospecimen_type`` are derived from.
+"""
+
+from __future__ import annotations
+
+# <tissue>/<materialType> — surgical/tumour tissue (report §6.3.2)
+TISSUE_MATERIAL_TYPES: dict[str, str] = {
+    "1": "Malignant tumour",
+    "2": "Metastasis",
+    "3": "Benign tumour",
+    "4": "Healthy/normal tissue",
+    "5": "Premalignant tissue",
+    "7": "Peripheral blood mononuclear cells (PBMNC)",
+    "53": "Malignant tumour (RNAlater)",
+    "54": "Healthy tissue (RNAlater)",
+    "55": "Metastasis (RNAlater)",
+    "56": "Benign tumour (RNAlater)",
+}
+
+# <serum>/<materialType> — blood-derived liquid samples (report §6.3.3)
+SERUM_MATERIAL_TYPES: dict[str, str] = {
+    "K": "K3EDTA plasma, nitrogen-stored",
+    "SD": "Serum, nitrogen-stored",
+    "S": "Serum (room temperature / short-term)",
+    "PD": "Plasma, nitrogen-stored",
+    "L": "Li-heparin plasma, nitrogen-stored",
+    "T": "CTAD plasma, nitrogen-stored",
+    "C": "Plasma with DNA stabiliser",
+    "PR": "Primary cell cultures",
+}
+
+# <genome>/<materialType> — DNA / nucleic acid samples (report §6.3.4)
+GENOME_MATERIAL_TYPES: dict[str, str] = {
+    "PK": "Whole blood (for DNA extraction)",
+    "PS": "Whole blood with DNA stabiliser",
+    "gD": "Extracted genomic DNA",
+}
+
+# <diagnosisMaterial>/<materialType> — STS diagnostic specimens (report §6.4.1).
+# Always "S" (surgical/serum specimen) in observed data.
+DIAGNOSIS_MATERIAL_TYPES: dict[str, str] = {
+    "S": "Serum / surgical specimen",
+}
+
+# Sample-type discriminators accepted by :func:`material_type_label`.
+_LOOKUPS: dict[str, dict[str, str]] = {
+    "tissue": TISSUE_MATERIAL_TYPES,
+    "serum": SERUM_MATERIAL_TYPES,
+    "genome": GENOME_MATERIAL_TYPES,
+    "diagnosis_material": DIAGNOSIS_MATERIAL_TYPES,
+}
+
+
+def material_type_label(sample_type: str, code: str | None) -> str | None:
+    """Return the English label for a ``<materialType>`` code, or ``None`` if unknown.
+
+    ``sample_type`` is one of ``"tissue"``, ``"serum"``, ``"genome"`` or
+    ``"diagnosis_material"``; ``code`` is the raw code (e.g. ``"53"``, ``"SD"``).
+    """
+    if code is None:
+        return None
+    return _LOOKUPS.get(sample_type, {}).get(code)

--- a/apps/biobank_api/src/biobank_api/domain/models/patient.py
+++ b/apps/biobank_api/src/biobank_api/domain/models/patient.py
@@ -1,17 +1,114 @@
+"""Biobank patient domain model — the root ``<patient>`` element of one XML export file.
+
+Source of truth: ``docs/patient-data-report.md`` §5 (demographics) and §6.1 (the
+``<patient>`` element, its attributes and child blocks). One file = one patient, holding
+patient-level radiology ``<AccessionNumbers>``, an ``<LTS>`` block of archived research
+:class:`~biobank_api.domain.models.sample.Sample` rows, and an ``<STS>`` block of
+:class:`~biobank_api.domain.models.sample.DiagnosticSpecimen` records.
+
+Maps to FAIR Genomes: the patient attributes -> ``Personal`` (and ``consent`` ->
+``Individual consent``); the projection itself is left to the serialization boundary
+(this stays an XML-faithful source model). Pure: a frozen dataclass, no I/O, no
+framework imports. ``from_raw`` applies :mod:`biobank_api.domain.cleaning`;
+``__post_init__`` enforces invariants.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from biobank_api.domain.cleaning import (
+    clean_accessions,
+    clean_text,
+    parse_consent,
+    parse_month,
+    parse_sex,
+    parse_year,
+)
+from biobank_api.domain.enums import Sex
+from biobank_api.domain.models.sample import DiagnosticSpecimen, Sample
 
-@dataclass
-class Sample:
-    sample_id: str
-    material_type: str | None = None
+# Sanity bounds for a patient birth year (report observed 1928–2023, paediatric cases
+# into the 2000s); kept wide and clock-independent so validation stays deterministic.
+MIN_BIRTH_YEAR = 1900
+MAX_BIRTH_YEAR = 2100
 
 
-@dataclass
+@dataclass(frozen=True)
 class Patient:
-    patient_id: str
-    samples: list[Sample] = field(default_factory=list)
-    # TODO(#33): expand to the full FAIR Genomes shape the uploader's
-    # ClinicalBuilder consumes (personal + clinical + material).
+    """A biobank patient — the root ``<patient>`` element (report §6.1).
+
+    A ``consent="false"`` patient is exported as a self-closing stub with no clinical
+    data (report §4 / §7); that invariant is enforced below.
+
+    Example::
+
+        <patient biobank="MOU" consent="true" id="138423" month="--05" sex="female"
+                 year="1943"> ... <LTS>...</LTS> <STS>...</STS> </patient>
+    """
+
+    patient_id: str  # <patient id> attr  -> Personal.personal_identifier
+    biobank: str | None = None  # <patient biobank> attr (always "MOU" in this dataset)
+    consent: bool | None = None  # <patient consent> attr  -> Individual consent
+    sex: Sex | None = None  # <patient sex> attr  -> Personal.gender_at_birth
+    birth_year: int | None = None  # <patient year> gYear  -> Personal.year_of_birth
+    birth_month: int | None = (
+        None  # <patient month> gMonth (1-12; optional in the source)
+    )
+    accession_numbers: list[str] = field(
+        default_factory=list
+    )  # patient-level <AccessionNumbers>/<Number> (radiology linkage)
+    samples: list[Sample] = field(
+        default_factory=list
+    )  # <LTS> archived research samples
+    diagnostic_specimens: list[DiagnosticSpecimen] = field(
+        default_factory=list
+    )  # <STS> diagnostic specimens
+
+    def __post_init__(self) -> None:
+        if not self.patient_id.strip():
+            raise ValueError("patient_id must not be empty")
+        if self.birth_year is not None and not (
+            MIN_BIRTH_YEAR <= self.birth_year <= MAX_BIRTH_YEAR
+        ):
+            raise ValueError(f"birth_year out of range: {self.birth_year}")
+        if self.birth_month is not None and not (1 <= self.birth_month <= 12):
+            raise ValueError(f"birth_month must be 1-12, got {self.birth_month}")
+        # consent="false" => self-closing stub with no exported clinical data (report §4/§7).
+        if self.consent is False and (
+            self.samples or self.diagnostic_specimens or self.accession_numbers
+        ):
+            raise ValueError("a patient without consent must not carry clinical data")
+
+    @classmethod
+    def from_raw(
+        cls,
+        *,
+        patient_id: str | None,
+        biobank: str | None = None,
+        consent: str | None = None,
+        sex: str | None = None,
+        year: str | None = None,
+        month: str | None = None,
+        accession_numbers: list[str] | None = None,
+        samples: list[Sample] | None = None,
+        diagnostic_specimens: list[DiagnosticSpecimen] | None = None,
+    ) -> Patient:
+        """Build a :class:`Patient` from raw ``<patient>`` attribute strings.
+
+        ``samples`` / ``diagnostic_specimens`` are already-constructed child models (each
+        built via its own ``from_raw``); the scalar attributes are cleaned here.
+        """
+        return cls(
+            patient_id=clean_text(patient_id) or "",
+            biobank=clean_text(biobank),
+            consent=parse_consent(consent),
+            sex=parse_sex(sex),
+            birth_year=parse_year(year),
+            birth_month=parse_month(month),
+            accession_numbers=clean_accessions(accession_numbers),
+            samples=list(samples) if samples else [],
+            diagnostic_specimens=(
+                list(diagnostic_specimens) if diagnostic_specimens else []
+            ),
+        )

--- a/apps/biobank_api/src/biobank_api/domain/models/sample.py
+++ b/apps/biobank_api/src/biobank_api/domain/models/sample.py
@@ -1,0 +1,365 @@
+"""Biobank sample domain models (the ``<LTS>`` and ``<STS>`` blocks of a ``<patient>``).
+
+Source of truth: ``docs/patient-data-report.md`` — §6.3 Long-Term Storage (the archived
+research samples ``<tissue>`` / ``<serum>`` / ``<genome>``), §6.3.1 the shared sample
+attribute group, §6.4 Short-Term Storage (``<diagnosisMaterial>`` diagnostic specimens),
+and §6.5 the material-type code tables.
+
+The three LTS sample types share an attribute group (modelled on :class:`Sample`) and
+add a few type-specific children (the subclasses). All map to FAIR Genomes
+``Material``; the carried ICD-10 ``diagnosis`` links to ``Clinical``. STS
+:class:`DiagnosticSpecimen` records are *not* archived — the specimen is consumed during
+diagnosis — so they are modelled separately and only carry the diagnosis linkage.
+
+Models are pure: frozen dataclasses, no I/O, no framework imports. ``from_raw`` factories
+apply :mod:`biobank_api.domain.cleaning` to raw XML strings; ``__post_init__`` enforces
+invariants. Required fields are validated as non-empty; optional fields are validated
+only when present (the XML parser, issue #33, guarantees presence of schema-required
+values).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import ClassVar
+
+from biobank_api.domain.cleaning import (
+    clean_accessions,
+    clean_code,
+    clean_sample_id,
+    clean_text,
+    dash_to_none,
+    parse_int,
+    parse_retrieved,
+    parse_temporal,
+    parse_year,
+)
+from biobank_api.domain.enums import Retrieved
+from biobank_api.domain.models.material_types import material_type_label
+
+# Sanity bounds for a sample collection year (report observed 2022–2026); kept wide so
+# the domain tolerates historical/future exports without hard-coding the current date.
+MIN_COLLECTION_YEAR = 1900
+MAX_COLLECTION_YEAR = 2100
+
+
+def _to_datetime(value: date | datetime) -> datetime:
+    """Normalise a ``date``/``datetime`` to a ``datetime`` for safe ordering comparison."""
+    if isinstance(value, datetime):
+        return value
+    return datetime(value.year, value.month, value.day)
+
+
+@dataclass(frozen=True)
+class Sample:
+    """An archived Long-Term Storage sample — shared ``<tissue>``/``<serum>``/``<genome>``
+    attribute group (report §6.3.1). Maps to FAIR Genomes ``Material``.
+
+    Subclassed by :class:`TissueSample`, :class:`SerumSample` and :class:`GenomeSample`
+    for the type-specific child elements. A single collection event (same ``number``)
+    commonly yields several rows, one per ``materialType`` (report §6.3.2 / §7).
+    """
+
+    # Discriminator used to resolve ``material_type`` against the right lookup table;
+    # overridden by each subclass. Not a dataclass field.
+    _SAMPLE_TYPE: ClassVar[str] = ""
+
+    sample_id: str  # sampleId attr  -> Material.material_identifier
+    material_type: (
+        str  # <materialType> code  -> Material.biospecimen_type / pathological_state
+    )
+    event_number: int | None = None  # number attr (shared by all aliquots of one event)
+    collection_year: int | None = (
+        None  # year attr (sample collection year, not birth year)
+    )
+    biopsy: str | None = None  # biopsy attr ("-" -> None): pathology lab reference
+    predictive_number: str | None = (
+        None  # predictive_number attr ("-" -> None): sequencing reference
+    )
+    samples_no: int | None = None  # <samplesNo>: total aliquots created
+    available_samples_no: int | None = (
+        None  # <availableSamplesNo>: aliquots still available
+    )
+    accession_numbers: list[str] = field(
+        default_factory=list
+    )  # sample-level <AccessionNumbers>/<Number> (post-2024 files)
+
+    def __post_init__(self) -> None:
+        if not self.sample_id.strip():
+            raise ValueError("sample_id must not be empty")
+        if not self.material_type.strip():
+            raise ValueError("material_type must not be empty")
+        for name in ("event_number", "samples_no", "available_samples_no"):
+            value = getattr(self, name)
+            if value is not None and value < 0:
+                raise ValueError(f"{name} must not be negative, got {value}")
+        if self.collection_year is not None and not (
+            MIN_COLLECTION_YEAR <= self.collection_year <= MAX_COLLECTION_YEAR
+        ):
+            raise ValueError(f"collection_year out of range: {self.collection_year}")
+        if (
+            self.samples_no is not None
+            and self.available_samples_no is not None
+            and self.available_samples_no > self.samples_no
+        ):
+            raise ValueError(
+                "available_samples_no cannot exceed samples_no "
+                f"({self.available_samples_no} > {self.samples_no})"
+            )
+
+    @property
+    def material_type_label(self) -> str | None:
+        """English meaning of ``material_type`` for this sample type (report §6.5)."""
+        return material_type_label(self._SAMPLE_TYPE, self.material_type)
+
+
+@dataclass(frozen=True)
+class TissueSample(Sample):
+    """Frozen surgical/tumour ``<tissue>`` sample (report §6.3.2).
+
+    Example::
+
+        <tissue biopsy="2023/2872-1" number="181" predictive_number="2023/1052"
+                sampleId="BBM:2023:181:1" year="2023">
+          <samplesNo>3</samplesNo><availableSamplesNo>3</availableSamplesNo>
+          <materialType>1</materialType><pTNM>T1N0M</pTNM><morphology>8380/31</morphology>
+          <diagnosis>C56</diagnosis>
+          <cutTime>2023-03-24T11:15:00</cutTime><freezeTime>2023-03-24T11:20:00</freezeTime>
+          <retrieved>operational</retrieved>
+        </tissue>
+    """
+
+    _SAMPLE_TYPE: ClassVar[str] = "tissue"
+
+    diagnosis: str | None = None  # <diagnosis> ICD-10  -> Material.belongs_to_diagnosis
+    p_tnm: str | None = (
+        None  # <pTNM> pathological TNM staging (opaque free text, report §6.7)
+    )
+    morphology: str | None = None  # <morphology> ICD-O-3 code (report §6.8)
+    cut_time: date | datetime | None = None  # <cutTime>  -> Material.sampling_timestamp
+    freeze_time: date | datetime | None = (
+        None  # <freezeTime> (a few minutes after cutTime)
+    )
+    retrieved: Retrieved | None = None  # <retrieved> (usually "operational" for tissue)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.cut_time is not None and self.freeze_time is not None:
+            if _to_datetime(self.freeze_time) < _to_datetime(self.cut_time):
+                raise ValueError("freeze_time cannot precede cut_time")
+
+    @classmethod
+    def from_raw(
+        cls,
+        *,
+        sample_id: str | None,
+        material_type: str | None,
+        number: str | None = None,
+        year: str | None = None,
+        biopsy: str | None = None,
+        predictive_number: str | None = None,
+        samples_no: str | None = None,
+        available_samples_no: str | None = None,
+        accession_numbers: list[str] | None = None,
+        diagnosis: str | None = None,
+        p_tnm: str | None = None,
+        morphology: str | None = None,
+        cut_time: str | None = None,
+        freeze_time: str | None = None,
+        retrieved: str | None = None,
+    ) -> TissueSample:
+        """Build a :class:`TissueSample` from raw ``<tissue>`` XML strings."""
+        return cls(
+            sample_id=clean_sample_id(sample_id) or "",
+            material_type=clean_text(material_type) or "",
+            event_number=parse_int(number),
+            collection_year=parse_year(year),
+            biopsy=dash_to_none(biopsy),
+            predictive_number=dash_to_none(predictive_number),
+            samples_no=parse_int(samples_no),
+            available_samples_no=parse_int(available_samples_no),
+            accession_numbers=clean_accessions(accession_numbers),
+            diagnosis=clean_code(diagnosis),
+            p_tnm=clean_code(p_tnm),
+            morphology=clean_code(morphology),
+            cut_time=parse_temporal(cut_time),
+            freeze_time=parse_temporal(freeze_time),
+            retrieved=parse_retrieved(retrieved),
+        )
+
+
+@dataclass(frozen=True)
+class SerumSample(Sample):
+    """Frozen blood-derived liquid ``<serum>`` sample (report §6.3.3).
+
+    Example::
+
+        <serum biopsy="-" number="3249" predictive_number="-" sampleId="BBMs:2022:3249:SD"
+               year="2022">
+          <samplesNo>1</samplesNo><availableSamplesNo>1</availableSamplesNo>
+          <materialType>SD</materialType><takingDate>2022-12-07</takingDate>
+        </serum>
+    """
+
+    _SAMPLE_TYPE: ClassVar[str] = "serum"
+
+    diagnosis: str | None = (
+        None  # <diagnosis> ICD-10 (when linked to a diagnosis event)
+    )
+    taking_date: date | datetime | None = (
+        None  # <takingDate>  -> Material.sampling_timestamp
+    )
+    retrieved: Retrieved | None = None  # <retrieved> (present ~60% of serum rows)
+
+    @classmethod
+    def from_raw(
+        cls,
+        *,
+        sample_id: str | None,
+        material_type: str | None,
+        number: str | None = None,
+        year: str | None = None,
+        biopsy: str | None = None,
+        predictive_number: str | None = None,
+        samples_no: str | None = None,
+        available_samples_no: str | None = None,
+        accession_numbers: list[str] | None = None,
+        diagnosis: str | None = None,
+        taking_date: str | None = None,
+        retrieved: str | None = None,
+    ) -> SerumSample:
+        """Build a :class:`SerumSample` from raw ``<serum>`` XML strings."""
+        return cls(
+            sample_id=clean_sample_id(sample_id) or "",
+            material_type=clean_text(material_type) or "",
+            event_number=parse_int(number),
+            collection_year=parse_year(year),
+            biopsy=dash_to_none(biopsy),
+            predictive_number=dash_to_none(predictive_number),
+            samples_no=parse_int(samples_no),
+            available_samples_no=parse_int(available_samples_no),
+            accession_numbers=clean_accessions(accession_numbers),
+            diagnosis=clean_code(diagnosis),
+            taking_date=parse_temporal(taking_date),
+            retrieved=parse_retrieved(retrieved),
+        )
+
+
+@dataclass(frozen=True)
+class GenomeSample(Sample):
+    """Frozen DNA / nucleic-acid ``<genome>`` sample (report §6.3.4).
+
+    Example::
+
+        <genome biopsy="-" number="249" predictive_number="-" sampleId="BBMd:2023:249:PK"
+                year="2023">
+          <samplesNo>1</samplesNo><availableSamplesNo>1</availableSamplesNo>
+          <materialType>PK</materialType><takingDate>2023-03-24</takingDate>
+          <retrieved>unknown</retrieved>
+        </genome>
+    """
+
+    _SAMPLE_TYPE: ClassVar[str] = "genome"
+
+    taking_date: date | datetime | None = (
+        None  # <takingDate>  -> Material.sampling_timestamp
+    )
+    retrieved: Retrieved | None = None  # <retrieved>
+
+    @classmethod
+    def from_raw(
+        cls,
+        *,
+        sample_id: str | None,
+        material_type: str | None,
+        number: str | None = None,
+        year: str | None = None,
+        biopsy: str | None = None,
+        predictive_number: str | None = None,
+        samples_no: str | None = None,
+        available_samples_no: str | None = None,
+        accession_numbers: list[str] | None = None,
+        taking_date: str | None = None,
+        retrieved: str | None = None,
+    ) -> GenomeSample:
+        """Build a :class:`GenomeSample` from raw ``<genome>`` XML strings."""
+        return cls(
+            sample_id=clean_sample_id(sample_id) or "",
+            material_type=clean_text(material_type) or "",
+            event_number=parse_int(number),
+            collection_year=parse_year(year),
+            biopsy=dash_to_none(biopsy),
+            predictive_number=dash_to_none(predictive_number),
+            samples_no=parse_int(samples_no),
+            available_samples_no=parse_int(available_samples_no),
+            accession_numbers=clean_accessions(accession_numbers),
+            taking_date=parse_temporal(taking_date),
+            retrieved=parse_retrieved(retrieved),
+        )
+
+
+@dataclass(frozen=True)
+class DiagnosticSpecimen:
+    """A Short-Term Storage ``<diagnosisMaterial>`` record (report §6.4.1).
+
+    Diagnostic specimen processed for diagnosis and consumed in the process — not
+    archived for research. It exists purely to link the patient's ICD-10 ``diagnosis``
+    to a collection event, so it maps to FAIR Genomes ``Clinical.clinical_diagnosis``
+    rather than ``Material``.
+
+    Example::
+
+        <diagnosisMaterial number="118485" sampleId="&:2022:118485" year="2022">
+          <materialType>S</materialType><diagnosis>C504</diagnosis>
+          <takingDate>2022-09-20T10:44:00</takingDate><retrieved>unknown</retrieved>
+        </diagnosisMaterial>
+    """
+
+    sample_id: str  # sampleId attr ("&:{year}:{number}", report §7 on the "&" prefix)
+    specimen_number: int | None = None  # number attr
+    year: int | None = None  # year attr
+    material_type: str | None = None  # <materialType> (always "S" in observed data)
+    diagnosis: str | None = None  # <diagnosis> ICD-10  -> Clinical.clinical_diagnosis
+    taking_date: date | datetime | None = None  # <takingDate>
+    retrieved: Retrieved | None = None  # <retrieved> (always "unknown" for STS)
+
+    def __post_init__(self) -> None:
+        if not self.sample_id.strip():
+            raise ValueError("sample_id must not be empty")
+        if self.specimen_number is not None and self.specimen_number < 0:
+            raise ValueError(
+                f"specimen_number must not be negative, got {self.specimen_number}"
+            )
+        if self.year is not None and not (
+            MIN_COLLECTION_YEAR <= self.year <= MAX_COLLECTION_YEAR
+        ):
+            raise ValueError(f"year out of range: {self.year}")
+
+    @property
+    def material_type_label(self) -> str | None:
+        """English meaning of ``material_type`` (report §6.5)."""
+        return material_type_label("diagnosis_material", self.material_type)
+
+    @classmethod
+    def from_raw(
+        cls,
+        *,
+        sample_id: str | None,
+        number: str | None = None,
+        year: str | None = None,
+        material_type: str | None = None,
+        diagnosis: str | None = None,
+        taking_date: str | None = None,
+        retrieved: str | None = None,
+    ) -> DiagnosticSpecimen:
+        """Build a :class:`DiagnosticSpecimen` from raw ``<diagnosisMaterial>`` XML strings."""
+        return cls(
+            sample_id=clean_sample_id(sample_id) or "",
+            specimen_number=parse_int(number),
+            year=parse_year(year),
+            material_type=clean_text(material_type),
+            diagnosis=clean_code(diagnosis),
+            taking_date=parse_temporal(taking_date),
+            retrieved=parse_retrieved(retrieved),
+        )

--- a/apps/biobank_api/tests/test_cleaning.py
+++ b/apps/biobank_api/tests/test_cleaning.py
@@ -1,0 +1,120 @@
+"""Unit tests for the domain cleaning/normalization helpers."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from biobank_api.domain.cleaning import (
+    clean_accessions,
+    clean_code,
+    clean_sample_id,
+    clean_text,
+    dash_to_none,
+    parse_consent,
+    parse_int,
+    parse_month,
+    parse_retrieved,
+    parse_sex,
+    parse_temporal,
+    parse_year,
+)
+from biobank_api.domain.enums import Retrieved, Sex
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("  MOU ", "MOU"), ("", None), ("   ", None), (None, None)],
+)
+def test_clean_text(raw: str | None, expected: str | None) -> None:
+    assert clean_text(raw) == expected
+
+
+def test_clean_code_preserves_case() -> None:
+    assert clean_code(" C504 ") == "C504"
+    assert clean_code("8500/32") == "8500/32"
+
+
+def test_clean_sample_id_keeps_sts_ampersand_prefix() -> None:
+    assert clean_sample_id(" BBM:2023:181:1 ") == "BBM:2023:181:1"
+    assert clean_sample_id("&:2022:118485") == "&:2022:118485"
+
+
+def test_clean_accessions_strips_and_drops_empty() -> None:
+    assert clean_accessions([" RDG1 ", "", "RDG2"]) == ["RDG1", "RDG2"]
+    assert clean_accessions(None) == []
+    assert clean_accessions([]) == []
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("-", None), ("2023/2872-1", "2023/2872-1"), ("", None), (None, None)],
+)
+def test_dash_to_none(raw: str | None, expected: str | None) -> None:
+    assert dash_to_none(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("true", True), ("TRUE", True), ("false", False), ("", None), (None, None)],
+)
+def test_parse_consent(raw: str | None, expected: bool | None) -> None:
+    assert parse_consent(raw) == expected
+
+
+def test_parse_consent_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        parse_consent("maybe")
+
+
+def test_parse_sex() -> None:
+    assert parse_sex("female") is Sex.FEMALE
+    assert parse_sex("MALE") is Sex.MALE
+    assert parse_sex("") is None
+    with pytest.raises(ValueError):
+        parse_sex("other")
+
+
+def test_parse_retrieved() -> None:
+    assert parse_retrieved("operational") is Retrieved.OPERATIONAL
+    assert parse_retrieved("unknown") is Retrieved.UNKNOWN
+    assert parse_retrieved(None) is None
+    with pytest.raises(ValueError):
+        parse_retrieved("nope")
+
+
+def test_parse_int() -> None:
+    assert parse_int(" 524 ") == 524
+    assert parse_int("") is None
+    with pytest.raises(ValueError):
+        parse_int("x")
+
+
+def test_parse_year() -> None:
+    assert parse_year("2023") == 2023
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("--07", 7), ("7", 7), ("--12", 12), ("", None), (None, None)],
+)
+def test_parse_month(raw: str | None, expected: int | None) -> None:
+    assert parse_month(raw) == expected
+
+
+def test_parse_temporal_datetime() -> None:
+    result = parse_temporal("2023-03-24T11:15:00")
+    assert result == datetime(2023, 3, 24, 11, 15)
+    assert isinstance(result, datetime)
+
+
+def test_parse_temporal_date_only() -> None:
+    result = parse_temporal("2023-03-24")
+    assert result == date(2023, 3, 24)
+    # date-only must stay a plain date, not a midnight datetime.
+    assert type(result) is date
+
+
+def test_parse_temporal_empty() -> None:
+    assert parse_temporal("") is None

--- a/apps/biobank_api/tests/test_domain_models.py
+++ b/apps/biobank_api/tests/test_domain_models.py
@@ -1,0 +1,262 @@
+"""Unit tests for the biobank domain models: construction, ``from_raw``, invariants.
+
+The ``from_raw`` cases mirror the example files in ``docs/patient-data-report.md`` §8.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from biobank_api.domain.enums import Retrieved, Sex
+from biobank_api.domain.models import (
+    DiagnosticSpecimen,
+    GenomeSample,
+    Patient,
+    Sample,
+    SerumSample,
+    TissueSample,
+    material_type_label,
+)
+
+# --- construction + material-type labels -----------------------------------------
+
+
+def test_sample_base_constructs_and_labels_unknown_type_as_none() -> None:
+    sample = Sample(sample_id="BBM:2023:181:1", material_type="1")
+    # the abstract base has no sample-type discriminator, so no label is resolved
+    assert sample.material_type_label is None
+
+
+def test_tissue_sample_material_type_label() -> None:
+    sample = TissueSample(sample_id="BBM:2023:181:53", material_type="53")
+    assert sample.material_type_label == "Malignant tumour (RNAlater)"
+
+
+def test_material_type_label_unknown_code_is_none() -> None:
+    assert material_type_label("tissue", "999") is None
+    assert material_type_label("serum", None) is None
+
+
+# --- from_raw mirrors report §8 examples ------------------------------------------
+
+
+def test_tissue_from_raw_example5() -> None:
+    sample = TissueSample.from_raw(
+        sample_id="BBM:2023:181:1",
+        material_type="1",
+        number="181",
+        year="2023",
+        biopsy="2023/2872-1",
+        predictive_number="2023/1052",
+        samples_no="3",
+        available_samples_no="3",
+        diagnosis="C56",
+        p_tnm="T1N0M",
+        morphology="8380/31",
+        cut_time="2023-03-24T11:15:00",
+        freeze_time="2023-03-24T11:20:00",
+        retrieved="operational",
+    )
+    assert sample.sample_id == "BBM:2023:181:1"
+    assert sample.material_type == "1"
+    assert sample.event_number == 181
+    assert sample.collection_year == 2023
+    assert sample.biopsy == "2023/2872-1"
+    assert sample.predictive_number == "2023/1052"
+    assert sample.samples_no == 3
+    assert sample.available_samples_no == 3
+    assert sample.diagnosis == "C56"
+    assert sample.p_tnm == "T1N0M"
+    assert sample.morphology == "8380/31"
+    assert sample.cut_time == datetime(2023, 3, 24, 11, 15)
+    assert sample.freeze_time == datetime(2023, 3, 24, 11, 20)
+    assert sample.retrieved is Retrieved.OPERATIONAL
+
+
+def test_serum_from_raw_example3_dash_sentinels() -> None:
+    sample = SerumSample.from_raw(
+        sample_id="BBMs:2022:3249:SD",
+        material_type="SD",
+        number="3249",
+        year="2022",
+        biopsy="-",
+        predictive_number="-",
+        samples_no="1",
+        available_samples_no="1",
+        taking_date="2022-12-07",
+    )
+    assert sample.biopsy is None
+    assert sample.predictive_number is None
+    assert sample.material_type == "SD"
+    assert sample.taking_date == date(2022, 12, 7)
+    assert sample.material_type_label == "Serum, nitrogen-stored"
+
+
+def test_genome_from_raw_example4() -> None:
+    sample = GenomeSample.from_raw(
+        sample_id="BBMd:2025:1075:PS",
+        material_type="PS",
+        number="1075",
+        year="2025",
+        biopsy="-",
+        predictive_number="-",
+        samples_no="1",
+        available_samples_no="1",
+        accession_numbers=[],
+        taking_date="2025-07-29",
+    )
+    assert sample.sample_id == "BBMd:2025:1075:PS"
+    assert sample.material_type == "PS"
+    assert sample.taking_date == date(2025, 7, 29)
+    assert sample.accession_numbers == []
+
+
+def test_diagnostic_specimen_from_raw_example2() -> None:
+    specimen = DiagnosticSpecimen.from_raw(
+        sample_id="&:2022:118485",
+        number="118485",
+        year="2022",
+        material_type="S",
+        diagnosis="C504",
+        taking_date="2022-09-20T10:44:00",
+        retrieved="unknown",
+    )
+    assert specimen.sample_id == "&:2022:118485"
+    assert specimen.specimen_number == 118485
+    assert specimen.year == 2022
+    assert specimen.material_type == "S"
+    assert specimen.diagnosis == "C504"
+    assert specimen.taking_date == datetime(2022, 9, 20, 10, 44)
+    assert specimen.retrieved is Retrieved.UNKNOWN
+    assert specimen.material_type_label == "Serum / surgical specimen"
+
+
+def test_patient_from_raw_consent_false_stub_example1() -> None:
+    patient = Patient.from_raw(
+        patient_id="271801",
+        biobank="MOU",
+        consent="false",
+        sex="male",
+        year="1948",
+        month="--07",
+    )
+    assert patient.patient_id == "271801"
+    assert patient.biobank == "MOU"
+    assert patient.consent is False
+    assert patient.sex is Sex.MALE
+    assert patient.birth_year == 1948
+    assert patient.birth_month == 7
+    assert patient.samples == []
+
+
+def test_patient_from_raw_with_children() -> None:
+    serum = SerumSample.from_raw(
+        sample_id="BBMs:2022:3249:SD", material_type="SD", taking_date="2022-12-07"
+    )
+    sts = DiagnosticSpecimen.from_raw(
+        sample_id="&:2022:155548", diagnosis="Z129", taking_date="2022-12-07T07:35:00"
+    )
+    patient = Patient.from_raw(
+        patient_id="138423",
+        consent="true",
+        sex="female",
+        year="1943",
+        accession_numbers=[" RDG2005041156 "],
+        samples=[serum],
+        diagnostic_specimens=[sts],
+    )
+    assert patient.accession_numbers == ["RDG2005041156"]
+    assert patient.samples == [serum]
+    assert patient.diagnostic_specimens == [sts]
+
+
+# --- backward-compatible minimal construction (scaffold call-sites) ---------------
+
+
+def test_patient_minimal_construction_stays_valid() -> None:
+    patient = Patient(patient_id="P1")
+    assert patient.samples == []
+    assert patient.diagnostic_specimens == []
+
+
+# --- invariants -------------------------------------------------------------------
+
+
+def test_patient_rejects_empty_id() -> None:
+    with pytest.raises(ValueError):
+        Patient(patient_id="  ")
+
+
+@pytest.mark.parametrize("birth_month", [0, 13, -1])
+def test_patient_rejects_out_of_range_month(birth_month: int) -> None:
+    with pytest.raises(ValueError):
+        Patient(patient_id="P1", birth_month=birth_month)
+
+
+@pytest.mark.parametrize("birth_year", [1850, 2200])
+def test_patient_rejects_out_of_range_year(birth_year: int) -> None:
+    with pytest.raises(ValueError):
+        Patient(patient_id="P1", birth_year=birth_year)
+
+
+def test_patient_without_consent_must_not_carry_data() -> None:
+    serum = SerumSample(sample_id="BBMs:2022:3249:SD", material_type="SD")
+    with pytest.raises(ValueError):
+        Patient(patient_id="P1", consent=False, samples=[serum])
+    with pytest.raises(ValueError):
+        Patient(patient_id="P1", consent=False, accession_numbers=["RDG1"])
+
+
+def test_sample_rejects_empty_required_fields() -> None:
+    with pytest.raises(ValueError):
+        TissueSample(sample_id="", material_type="1")
+    with pytest.raises(ValueError):
+        TissueSample(sample_id="BBM:2023:181:1", material_type="")
+
+
+def test_sample_rejects_available_exceeding_total() -> None:
+    with pytest.raises(ValueError):
+        SerumSample(
+            sample_id="BBMs:2022:3249:SD",
+            material_type="SD",
+            samples_no=1,
+            available_samples_no=2,
+        )
+
+
+def test_sample_rejects_negative_counts() -> None:
+    with pytest.raises(ValueError):
+        SerumSample(sample_id="BBMs:2022:3249:SD", material_type="SD", samples_no=-1)
+
+
+def test_tissue_rejects_freeze_before_cut() -> None:
+    with pytest.raises(ValueError):
+        TissueSample(
+            sample_id="BBM:2023:181:1",
+            material_type="1",
+            cut_time=datetime(2023, 3, 24, 11, 20),
+            freeze_time=datetime(2023, 3, 24, 11, 15),
+        )
+
+
+def test_tissue_allows_mixed_date_and_datetime_ordering() -> None:
+    # freeze (datetime) after cut (date) — comparison must not raise TypeError.
+    sample = TissueSample(
+        sample_id="BBM:2023:181:1",
+        material_type="1",
+        cut_time=date(2023, 3, 24),
+        freeze_time=datetime(2023, 3, 24, 11, 20),
+    )
+    assert sample.freeze_time == datetime(2023, 3, 24, 11, 20)
+
+
+def test_diagnostic_specimen_rejects_empty_id() -> None:
+    with pytest.raises(ValueError):
+        DiagnosticSpecimen(sample_id="")
+
+
+def test_diagnostic_specimen_rejects_out_of_range_year() -> None:
+    with pytest.raises(ValueError):
+        DiagnosticSpecimen(sample_id="&:2022:118485", year=1800)


### PR DESCRIPTION
﻿## Summary
Define the biobank service's pure domain model: typed, framework-free Patient / Sample / Clinical entities built from the documented XML export, with field invariants and raw-value cleaning living in the domain layer.

## Motivation
Closes #34. The service needs typed domain models independent of XML/DB concerns, and raw XML values (dates, gMonth, codes, "-" sentinels) need cleaning/normalization — logic that belongs in a dedicated domain layer rather than passthrough.

## Changes
- Add `Patient` (`<patient>`): demographics, consent, accession numbers, LTS samples, STS diagnostic specimens.
- Add `Sample` base + `TissueSample` / `SerumSample` / `GenomeSample` (LTS) and `DiagnosticSpecimen` (STS), each with a `from_raw()` factory.
- Add `cleaning.py` (gMonth / xs:date|xs:dateTime / consent / sex / "-" sentinel parsing), `enums.py` (`Sex`, `Retrieved`), and `material_types.py` (report section 6.5 code -> label lookups).
- Field-level invariants in `__post_init__`: birth year/month ranges, consent-stub rule, available <= total, tissue freeze >= cut.
- Every field documents its XML origin and FAIR Genomes target; classes cite docs/patient-data-report.md sections with sample snippets.
- Unit tests for construction, from_raw cleaning, and every invariant (mirroring report section 8 example files).

Domain-only scope: the parser/repo/web scaffolds (#33) are untouched and remain green. CI checks (ruff, ruff format, mypy, pytest, uv lock) pass locally for biobank_api (56 tests).
