### PR TITLE
Scaffold the Sequencing API service

### DIFF
--- a/.claude/skills/dotnet-dev/SKILL.md
+++ b/.claude/skills/dotnet-dev/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dotnet-dev
-description: Coding patterns and architecture rules for the data-catalogue-upload .NET solution. Use when writing or modifying C# under src/ in either service (BiobankApi or Uploader) - adding domain aggregates/value objects, application use cases (Mediator commands/queries) and ports, infrastructure adapters (EF Core repositories, the biobank XML reader, the uploader's typed HttpClient gateways), or hand-written mappers. Covers the solution layout, Clean Architecture layer boundaries, ErrorOr validation, FluentValidation request validators, central package management, and the build/format/test loop.
+description: Coding patterns and architecture rules for the data-catalogue-upload .NET solution. Use when writing or modifying C# under src/ in any service (BiobankApi, SequencingApi, or Uploader) - adding domain aggregates/value objects, application use cases (Mediator commands/queries) and ports, infrastructure adapters (EF Core repositories, the biobank XML reader, the uploader's typed HttpClient gateways), or hand-written mappers. Covers the solution layout, Clean Architecture layer boundaries, ErrorOr validation, FluentValidation request validators, central package management, and the build/format/test loop.
 ---
 
 # .NET development (data-catalogue-upload)
 
-One **.NET 10 solution** (`DataCatalogueUpload.slnx`) with two services under `src/`, each its own set of
+One **.NET 10 solution** (`DataCatalogueUpload.slnx`) with services under `src/`, each its own set of
 projects following **Clean Architecture + DDD**. Keep changes inside the right layer and the right service,
 and validate with `dotnet format` + `dotnet build` before finishing.
 
@@ -13,8 +13,9 @@ and validate with `dotnet format` + `dotnet build` before finishing.
 
 ```
 src/
-├── BiobankApi/   BiobankApi.{Domain,Application,Infrastructure,Web}
-└── Uploader/     Uploader.{Domain,Application,Infrastructure,Host}
+├── BiobankApi/     BiobankApi.{Domain,Application,Infrastructure,Web}
+├── SequencingApi/  SequencingApi.{Domain,Application,Infrastructure,Web}   (scaffold - stub host, no domain/migration yet)
+└── Uploader/       Uploader.{Domain,Application,Infrastructure,Host}
 ```
 
 - **TFM `net10.0`**, nullable + implicit usings on, **warnings are errors** (set in `Directory.Build.props`).

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: testing
-description: Test conventions for the data-catalogue-upload .NET solution. Use when writing, running, or fixing tests in the four test projects under tests/ - unit-testing domain aggregates/factories, the FingerprintSyncPlanner, the SourceMapper and the sync handler with hand-written fakes; integration-testing EF Core repositories against in-memory SQLite (the SqliteDatabase helper) and the biobank API with WebApplicationFactory<Program>. xUnit, plain Assert, no mocking libraries.
+description: Test conventions for the data-catalogue-upload .NET solution. Use when writing, running, or fixing tests in the test projects under tests/ (unit + integration per service) - unit-testing domain aggregates/factories, the FingerprintSyncPlanner, the SourceMapper and the sync handler with hand-written fakes; integration-testing EF Core repositories against in-memory SQLite (the SqliteDatabase helper) and the API hosts with WebApplicationFactory<Program>. xUnit, plain Assert, no mocking libraries.
 ---
 
 # Testing (data-catalogue-upload)
 
-Tests live under `tests/`, split into four projects - two per service, **unit** and **integration**:
+Tests live under `tests/`, two projects per service - **unit** and **integration**:
 
 ```
 tests/
-├── BiobankApi.UnitTests          DomainModelsTests (aggregates/factories), XmlPatientReaderTests (pure XML->domain)
-├── BiobankApi.IntegrationTests   ApiTests, RepositoryTests, MapperTests, XmlValueReaderTests, XmlExportParserTests
-├── Uploader.UnitTests            FingerprintSyncPlannerTests, FingerprintTests, SourceMapperTests, RunCatalogueSyncHandlerTests
-└── Uploader.IntegrationTests     SyncStateRepositoryTests
+├── BiobankApi.UnitTests             DomainModelsTests (aggregates/factories), XmlPatientReaderTests (pure XML->domain)
+├── BiobankApi.IntegrationTests      ApiTests, RepositoryTests, MapperTests, XmlValueReaderTests, XmlExportParserTests
+├── SequencingApi.UnitTests          StubDataSourceTests (scaffold; grows with #30)
+├── SequencingApi.IntegrationTests   ApiTests (health + POST /admin/ingest over WebApplicationFactory)
+├── Uploader.UnitTests               FingerprintSyncPlannerTests, FingerprintTests, SourceMapperTests, RunCatalogueSyncHandlerTests
+└── Uploader.IntegrationTests        SyncStateRepositoryTests
 ```
 
 Framework is **xUnit** (`[Fact]` / `[Theory]`) with plain `Assert.*`. **No FluentAssertions, no Moq /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,11 @@ Guidance for AI coding agents (primarily Claude Code) working in this repository
 
 ## Project
 
-`data-catalogue-upload` is a **.NET solution** for the data-catalogue sync system. The solution is `DataCatalogueUpload.slnx` at the repo root. The two services:
+`data-catalogue-upload` is a **.NET solution** for the data-catalogue sync system. The solution is `DataCatalogueUpload.slnx` at the repo root. The services:
 
 - **uploader** (`src/Uploader`) - a scheduled, one-shot sync job. For each patient it reads from four source APIs (biobank, radiology, sequencing, WSI), aggregates the data into one FAIR Genomes-shaped patient record, compares it against fingerprints stored in PostgreSQL, and upserts/deletes records in a central data catalogue API.
 - **biobank_api** (`src/BiobankApi`) - a source API service that parses biobank XML exports and serves the patient/sample/clinical endpoints the uploader consumes.
+- **sequencing_api** (`src/SequencingApi`) - source API service for sequencing data. Currently a **scaffold** (host + stub ingestion; no domain aggregate or EF migration yet - those land with #30). Same layering and in-process Quartz ingestion as biobank_api.
 
 Read [`ARCHITECTURE.md`](ARCHITECTURE.md) for the data flow and layering, and [`DEVELOPMENT.md`](DEVELOPMENT.md) for setup and local run instructions.
 
@@ -20,10 +21,12 @@ Read [`ARCHITECTURE.md`](ARCHITECTURE.md) for the data flow and layering, and [`
 ```
 DataCatalogueUpload.slnx  Directory.Build.props  Directory.Packages.props  global.json
 src/
-├── BiobankApi/   BiobankApi.{Domain,Application,Infrastructure,Web}
-└── Uploader/     Uploader.{Domain,Application,Infrastructure,Host}
+├── BiobankApi/     BiobankApi.{Domain,Application,Infrastructure,Web}
+├── SequencingApi/  SequencingApi.{Domain,Application,Infrastructure,Web}
+└── Uploader/       Uploader.{Domain,Application,Infrastructure,Host}
 tests/
 ├── BiobankApi.{UnitTests,IntegrationTests}
+├── SequencingApi.{UnitTests,IntegrationTests}
 └── Uploader.{UnitTests,IntegrationTests}
 ```
 
@@ -40,6 +43,10 @@ Dependency direction per service: `Web`/`Host` -> `Infrastructure` -> `Applicati
 ## biobank_api
 
 EF Core (Npgsql) + LINQ-to-XML (`System.Xml.Linq`). Domain `PatientAggregate` with `TissueSample`/`SerumSample`/`GenomeSample` and `DiagnosticSpecimen`; invariants enforced by `Create(...)` factories returning `ErrorOr`. Ingestion reads exports behind the `IPatientExportSource` port (`XmlExportParser` discovers files, the pure `XmlPatientReader` maps each `<patient>`); there is exactly one source per biobank, and the handler reads it and reports invalid records in an `IngestExportsCommandResult`. The Application ports live in subfolders: `Abstractions/Export/` (`IPatientExportSource`, `ExportParseResult`, `ExportParseError`) and `Abstractions/Repositories/` (`IBiobankRepository`). CQRS: `GetPatientsQuery`, `IngestExportsCommand`. Host `BiobankApi.Web` runs the Minimal API and a **weekly Quartz job** (`IngestionJob`) that dispatches `IngestExportsCommand`; ingestion can also be triggered on demand via `POST /admin/ingest`. Config via env vars (`POSTGRES_*`, `BIOBANK_*` incl. `BIOBANK_INGEST_CRON` for the schedule); see `BiobankOptions`.
+
+## sequencing_api
+
+**Scaffold** mirroring biobank_api (host + stub ingestion; the sequencing domain, repository and first EF migration land with #30). Domain has only the `Common/` base types. Ingestion reads the `ISequencingDataSource` port (`Abstractions/DataSource/`); the current `StubSequencingDataSource` reports zero records so `IngestRecordsCommand` runs end-to-end. Host `SequencingApi.Web` runs the Minimal API (`GET /health`, `POST /admin/ingest`) and a **weekly Quartz job** (`IngestionJob`). Config via env vars (`POSTGRES_*`, `SEQUENCING_*` incl. `SEQUENCING_INGEST_CRON`); see `SequencingOptions`. Search for `ponytail:` to find the spots to fill in.
 
 ## uploader
 
@@ -58,6 +65,7 @@ dotnet format DataCatalogueUpload.slnx --verify-no-changes   # lint/format (drop
 # EF Core migrations
 dotnet ef migrations add <Name> --project src/BiobankApi/BiobankApi.Infrastructure --startup-project src/BiobankApi/BiobankApi.Web -o Persistence/Migrations
 dotnet ef migrations add <Name> --project src/Uploader/Uploader.Infrastructure   --startup-project src/Uploader/Uploader.Host    -o Persistence/Migrations
+# sequencing_api has no entities yet (#30); once it does, the same command with SequencingApi paths applies.
 ```
 
 ## Conventions
@@ -87,4 +95,4 @@ dotnet test DataCatalogueUpload.slnx
 - Do not bypass the layers (no EF Core / `HttpClient` / `XmlReader` in `Application` or `Domain`).
 - Do not put NuGet versions on individual `PackageReference`s - use central package management.
 - Do not loosen analyzer/format settings to silence errors; fix the code instead.
-- Do not introduce a shared project between the two services - keep their domains decoupled.
+- Do not introduce a shared project between the services - keep their domains decoupled.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # Architecture Overview
 
-> This repository is a **.NET solution** (`DataCatalogueUpload.slnx`). The two services - the `uploader`
-> sync job and the `biobank_api` source API - live under `src/`. This document describes the
-> **uploader** and the end-to-end data flow; each service follows the same Clean Architecture layering.
-> See [`AGENTS.md`](AGENTS.md) for the solution layout.
+> This repository is a **.NET solution** (`DataCatalogueUpload.slnx`). The services - the `uploader`
+> sync job and the source APIs (`biobank_api`, plus the `sequencing_api` scaffold) - live under `src/`.
+> This document describes the **uploader** and the end-to-end data flow; each service follows the same
+> Clean Architecture layering. See [`AGENTS.md`](AGENTS.md) for the solution layout.
 
 The uploader synchronizes patient-related data from multiple source systems into the data catalogue.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,16 +28,21 @@ docker compose -f compose.prod.yml up -d uploader-db biobank-db
 
 - `uploader-db` -> `localhost:5432`, database `data_catalogue_upload`
 - `biobank-db` -> `localhost:5433`, database `biobank_api`
+- `sequencing-db` -> `localhost:5434`, database `sequencing_api`
 
 Both default to `postgres` / `postgres`.
 
 ## Configuration
 
 Configuration is read from **environment variables** (no `.env` files are tracked). Defaults in
-`BiobankOptions` / `UploaderOptions` match the Docker databases above.
+`BiobankOptions` / `SequencingOptions` / `UploaderOptions` match the Docker databases above.
 
 **biobank_api:** `POSTGRES_USER|PASSWORD|DB|HOST|PORT`, `BIOBANK_HOST|PORT`, `BIOBANK_XML_EXPORT_PATH`.
 For local runs against `biobank-db`, set `POSTGRES_PORT=5433`.
+
+**sequencing_api** (scaffold): `POSTGRES_USER|PASSWORD|DB|HOST|PORT`, `SEQUENCING_HOST|PORT`,
+`SEQUENCING_DATA_PATH`, `SEQUENCING_INGEST_CRON`. For local runs against `sequencing-db`, set
+`POSTGRES_PORT=5434`.
 
 **uploader:** `POSTGRES_USER|PASSWORD|DB|HOST|PORT` plus the five API URLs
 `BIOBANK_API_URL`, `RADIOLOGY_API_URL`, `SEQUENCING_API_URL`, `WSI_API_URL`, `CATALOGUE_API_URL`.
@@ -61,8 +66,11 @@ dotnet ef migrations add <Name> \
   --output-dir Persistence/Migrations
 ```
 
-At runtime the **uploader** applies migrations on startup; the **biobank_api** applies them when
-`RUN_MIGRATIONS=true` is set (the container sets it; tests leave it unset).
+The **sequencing_api** has no entities yet (#30); the same commands with its `SequencingApi` paths
+apply once it does.
+
+At runtime the **uploader** applies migrations on startup; the **biobank_api** and **sequencing_api**
+apply them when `RUN_MIGRATIONS=true` is set (the container sets it; tests leave it unset).
 
 ## Running the services
 
@@ -73,6 +81,10 @@ RUN_MIGRATIONS=true POSTGRES_PORT=5433 dotnet run --project src/BiobankApi/Bioba
 # trigger biobank ingestion on the running API (also runs weekly via Quartz)
 curl -X POST http://localhost:8001/admin/ingest
 
+# sequencing API server (scaffold; http://localhost:8002)
+RUN_MIGRATIONS=true POSTGRES_PORT=5434 dotnet run --project src/SequencingApi/SequencingApi.Web
+curl -X POST http://localhost:8002/admin/ingest    # {"ingested":0,"failed":0,"errors":[]}
+
 # uploader sync job (prints a JSON summary; exit 0 = no failures, 1 = failures)
 dotnet run --project src/Uploader/Uploader.Host
 ```
@@ -80,8 +92,8 @@ dotnet run --project src/Uploader/Uploader.Host
 ## Tests
 
 - `*.UnitTests` - pure tests (domain services, planner, builders, handlers with fakes).
-- `*.IntegrationTests` - EF Core against in-memory SQLite via the `SqliteDatabase` helper; the biobank
-  API is exercised end-to-end with `WebApplicationFactory<Program>`.
+- `*.IntegrationTests` - EF Core against in-memory SQLite via the `SqliteDatabase` helper; the API
+  hosts are exercised end-to-end with `WebApplicationFactory<Program>`.
 
 ```bash
 dotnet test DataCatalogueUpload.slnx                                  # everything
@@ -91,7 +103,7 @@ dotnet test tests/Uploader.UnitTests/Uploader.UnitTests.csproj  # one project
 ## Containers
 
 ```bash
-docker compose -f compose.prod.yml up -d --build                # dbs + biobank-api
+docker compose -f compose.prod.yml up -d --build                # dbs + biobank-api + sequencing-api
 curl -X POST http://localhost:8001/admin/ingest                 # ingest on demand
 ```
 

--- a/DataCatalogueUpload.slnx
+++ b/DataCatalogueUpload.slnx
@@ -6,6 +6,12 @@
     <Project Path="src/BiobankApi/BiobankApi.Infrastructure/BiobankApi.Infrastructure.csproj" />
     <Project Path="src/BiobankApi/BiobankApi.Web/BiobankApi.Web.csproj" />
   </Folder>
+  <Folder Name="/src/SequencingApi/">
+    <Project Path="src/SequencingApi/SequencingApi.Application/SequencingApi.Application.csproj" />
+    <Project Path="src/SequencingApi/SequencingApi.Domain/SequencingApi.Domain.csproj" />
+    <Project Path="src/SequencingApi/SequencingApi.Infrastructure/SequencingApi.Infrastructure.csproj" />
+    <Project Path="src/SequencingApi/SequencingApi.Web/SequencingApi.Web.csproj" />
+  </Folder>
   <Folder Name="/src/Uploader/">
     <Project Path="src/Uploader/Uploader.Application/Uploader.Application.csproj" />
     <Project Path="src/Uploader/Uploader.Domain/Uploader.Domain.csproj" />
@@ -15,6 +21,8 @@
   <Folder Name="/tests/">
     <Project Path="tests/BiobankApi.IntegrationTests/BiobankApi.IntegrationTests.csproj" />
     <Project Path="tests/BiobankApi.UnitTests/BiobankApi.UnitTests.csproj" />
+    <Project Path="tests/SequencingApi.IntegrationTests/SequencingApi.IntegrationTests.csproj" />
+    <Project Path="tests/SequencingApi.UnitTests/SequencingApi.UnitTests.csproj" />
     <Project Path="tests/Uploader.IntegrationTests/Uploader.IntegrationTests.csproj" />
     <Project Path="tests/Uploader.UnitTests/Uploader.UnitTests.csproj" />
   </Folder>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ services it reads from. The solution is [`DataCatalogueUpload.slnx`](DataCatalog
 |---------|----------|------------|
 | uploader | [`src/Uploader`](src/Uploader) | Scheduled, one-shot sync job: aggregates per-patient data from the source APIs and upserts it into the data catalogue. |
 | biobank_api | [`src/BiobankApi`](src/BiobankApi) | Source API service: parses biobank XML exports and serves the patient/sample/clinical endpoints the uploader consumes. |
+| sequencing_api | [`src/SequencingApi`](src/SequencingApi) | Source API service for sequencing data (scaffold — domain and endpoints land with #30). Same Clean Architecture layering and in-process Quartz ingestion as biobank_api. |
 
 Each service is its own set of projects (Domain / Application / Infrastructure / host) following
 **Clean Architecture + DDD**: a rich domain with aggregates and domain services that enforce their

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -50,6 +50,40 @@ services:
     volumes:
       - /home/mou/patient_data:/data/exports:ro
 
+  # --- sequencing_api: its own PostgreSQL + server + (profiled) ingestion ---
+  sequencing-db:
+    image: postgres:16
+    container_name: sequencing-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sequencing_api
+    ports:
+      - "5434:5432"
+    volumes:
+      - sequencing_db_data:/var/lib/postgresql/data
+
+  sequencing-api:
+    build:
+      context: .
+      dockerfile: src/SequencingApi/SequencingApi.Web/Dockerfile
+    container_name: sequencing-api
+    restart: unless-stopped
+    environment:
+      POSTGRES_HOST: sequencing-db
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sequencing_api
+      ASPNETCORE_URLS: http://+:8002
+      RUN_MIGRATIONS: "true"
+    depends_on:
+      - sequencing-db
+    ports:
+      - "8002:8002"
+
 volumes:
   uploader_db_data:
   biobank_db_data:
+  sequencing_db_data:

--- a/src/SequencingApi/README.md
+++ b/src/SequencingApi/README.md
@@ -1,0 +1,49 @@
+# sequencing_api
+
+Source API service for sequencing data, part of the data-catalogue sync system (#30). It follows the
+same **Clean Architecture + DDD** layering as [biobank_api](../BiobankApi): a domain with aggregates
+and invariant factories, a CQRS application layer dispatched through the
+[`Mediator`](https://github.com/martinothamar/Mediator) source generator, EF Core for persistence, and
+an ASP.NET Core Minimal API host. Ingestion runs in-process in the Web host (weekly Quartz job +
+`POST /admin/ingest`).
+
+> **Status: scaffold.** No sequencing domain aggregate, repository or EF migration exists yet — those
+> land with feature work under #30. The stub ingestion source reports zero records so the pipeline runs
+> end-to-end. Search the tree for `ponytail:` to find the exact spots to fill in.
+
+## Projects
+
+| Layer | Project | Notes |
+|-------|---------|-------|
+| Domain | `SequencingApi.Domain` | `Common/` base types only (Entity, AggregateRoot, ValueObject, `IStronglyTypedId`). |
+| Application | `SequencingApi.Application` | `IngestRecordsCommand` + handler, `ISequencingDataSource` port, Mediator/FluentValidation wiring. |
+| Infrastructure | `SequencingApi.Infrastructure` | `SequencingDbContext` (no DbSets yet), `SequencingOptions`, design-time factory, `StubSequencingDataSource`. |
+| Web | `SequencingApi.Web` | Minimal-API host: `GET /health`, `POST /admin/ingest`, Quartz `IngestionJob`. |
+
+## Configuration (environment variables)
+
+Defaults keep the service runnable with no environment set.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `POSTGRES_HOST` / `POSTGRES_PORT` | `localhost` / `5434` | Database host/port. |
+| `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` | `sequencing_api` / `postgres` / `postgres` | Database name and credentials. |
+| `SEQUENCING_PORT` | `8002` | HTTP port (bind via `ASPNETCORE_URLS` in the container). |
+| `SEQUENCING_DATA_PATH` | `data/records` | Data source path (unused until the real source lands). |
+| `SEQUENCING_INGEST_CRON` | `0 0 17 ? * SUN` | Quartz ingestion schedule (Sundays 17:00 UTC). |
+| `DisableScheduler` | `false` | `true` disables the Quartz job (used by integration tests). |
+| `RUN_MIGRATIONS` | unset | `true` applies EF migrations on startup (set by the container). |
+
+## Running locally
+
+```bash
+# start the database
+docker compose -f compose.prod.yml up -d sequencing-db
+
+# run the API (applies EF migrations on startup when RUN_MIGRATIONS=true)
+RUN_MIGRATIONS=true POSTGRES_PORT=5434 \
+  dotnet run --project src/SequencingApi/SequencingApi.Web    # http://localhost:8002
+
+curl http://localhost:8002/health                 # {"status":"ok"}
+curl -X POST http://localhost:8002/admin/ingest    # {"ingested":0,"failed":0,"errors":[]}
+```

--- a/src/SequencingApi/SequencingApi.Application/Abstractions/DataSource/ISequencingDataSource.cs
+++ b/src/SequencingApi/SequencingApi.Application/Abstractions/DataSource/ISequencingDataSource.cs
@@ -1,0 +1,22 @@
+using ErrorOr;
+
+namespace SequencingApi.Application.Abstractions.DataSource;
+
+/// <summary>
+/// Source port that reads a sequencing facility's data into domain aggregates. Each unit read from the
+/// source (a "record") either validates into an aggregate or is reported as a <see cref="RecordReadError"/>.
+/// There is exactly one data source per facility, so this stays format-agnostic (the concrete format is
+/// decided with #30).
+/// </summary>
+public interface ISequencingDataSource
+{
+    /// <summary>A short label identifying the source, used when reporting read failures.</summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Read the source into domain aggregates, reporting per-record failures alongside them. Returns an
+    /// error when the source itself is unavailable (e.g. it is unreachable or empty), so a
+    /// misconfigured run fails loudly instead of looking like a successful ingest of nothing.
+    /// </summary>
+    ErrorOr<RecordReadResult> ReadRecords();
+}

--- a/src/SequencingApi/SequencingApi.Application/Abstractions/DataSource/RecordReadError.cs
+++ b/src/SequencingApi/SequencingApi.Application/Abstractions/DataSource/RecordReadError.cs
@@ -1,0 +1,9 @@
+namespace SequencingApi.Application.Abstractions.DataSource;
+
+/// <summary>
+/// A single record that could not be turned into a valid sequencing entity.
+/// </summary>
+/// <param name="Source">The data source that produced the record (see <see cref="ISequencingDataSource.Name"/>).</param>
+/// <param name="Reference">Where the record came from — typically the file name or record id.</param>
+/// <param name="Reason">Why it failed (the underlying validation/parse error description).</param>
+public sealed record RecordReadError(string Source, string Reference, string Reason);

--- a/src/SequencingApi/SequencingApi.Application/Abstractions/DataSource/RecordReadResult.cs
+++ b/src/SequencingApi/SequencingApi.Application/Abstractions/DataSource/RecordReadResult.cs
@@ -1,0 +1,12 @@
+namespace SequencingApi.Application.Abstractions.DataSource;
+
+/// <summary>
+/// The outcome of reading one data source: how many records validated successfully and the records
+/// that failed. Invalid records are reported here, never silently dropped.
+/// </summary>
+/// <remarks>
+/// ponytail: holds a count rather than the parsed aggregates because the sequencing domain has no
+/// aggregate yet (#30). When the aggregate lands, swap <c>RecordCount</c> for
+/// <c>IReadOnlyList&lt;SequencingAggregate&gt; Records</c>, mirroring BiobankApi's read result.
+/// </remarks>
+public sealed record RecordReadResult(int RecordCount, IReadOnlyList<RecordReadError> Errors);

--- a/src/SequencingApi/SequencingApi.Application/Behaviors/LoggingBehavior.cs
+++ b/src/SequencingApi/SequencingApi.Application/Behaviors/LoggingBehavior.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using Mediator;
+using Microsoft.Extensions.Logging;
+
+namespace SequencingApi.Application.Behaviors;
+
+/// <summary>
+/// Mediator pipeline behavior that logs the start, completion and elapsed time of every request.
+/// </summary>
+public sealed class LoggingBehavior<TMessage, TResponse>(ILogger<LoggingBehavior<TMessage, TResponse>> logger)
+    : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : notnull, IMessage
+{
+    public async ValueTask<TResponse> Handle(
+        TMessage message,
+        MessageHandlerDelegate<TMessage, TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        var requestName = typeof(TMessage).Name;
+        logger.LogInformation("Handling {RequestName}", requestName);
+
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            var response = await next(message, cancellationToken);
+            stopwatch.Stop();
+            logger.LogInformation(
+                "Handled {RequestName} in {ElapsedMilliseconds} ms",
+                requestName,
+                stopwatch.ElapsedMilliseconds);
+            return response;
+        }
+        catch (Exception exception)
+        {
+            stopwatch.Stop();
+            logger.LogError(
+                exception,
+                "Error handling {RequestName} after {ElapsedMilliseconds} ms",
+                requestName,
+                stopwatch.ElapsedMilliseconds);
+            throw;
+        }
+    }
+}

--- a/src/SequencingApi/SequencingApi.Application/Behaviors/ValidationBehavior.cs
+++ b/src/SequencingApi/SequencingApi.Application/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,47 @@
+using ErrorOr;
+using FluentValidation;
+using Mediator;
+
+namespace SequencingApi.Application.Behaviors;
+
+/// <summary>
+/// Mediator pipeline behavior that runs any registered FluentValidation validators for a request and
+/// short-circuits with their failures (as an <see cref="ErrorOr{TValue}"/> error response) before the
+/// handler runs. This is the <b>application-level</b> request gate; domain invariants still live in the
+/// aggregates' <c>Create</c> factories. Dormant until a validator is registered for a request type.
+/// </summary>
+public sealed class ValidationBehavior<TMessage, TResponse>(IEnumerable<IValidator<TMessage>> validators)
+    : IPipelineBehavior<TMessage, TResponse>
+    where TMessage : notnull, IMessage
+    where TResponse : IErrorOr
+{
+    public async ValueTask<TResponse> Handle(
+        TMessage message,
+        MessageHandlerDelegate<TMessage, TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (!validators.Any())
+        {
+            return await next(message, cancellationToken);
+        }
+
+        var context = new ValidationContext<TMessage>(message);
+        var results = await Task.WhenAll(
+            validators.Select(validator => validator.ValidateAsync(context, cancellationToken)));
+
+        var errors = results
+            .SelectMany(result => result.Errors)
+            .Where(failure => failure is not null)
+            .Select(failure => Error.Validation(failure.PropertyName, failure.ErrorMessage))
+            .ToList();
+
+        if (errors.Count == 0)
+        {
+            return await next(message, cancellationToken);
+        }
+
+        // ErrorOr<T> defines an implicit conversion from List<Error>; dynamic dispatch picks the
+        // closed response type. Safe because every request in this service returns ErrorOr<T>.
+        return (TResponse)(dynamic)errors;
+    }
+}

--- a/src/SequencingApi/SequencingApi.Application/DependencyInjection.cs
+++ b/src/SequencingApi/SequencingApi.Application/DependencyInjection.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using SequencingApi.Application.Behaviors;
+
+namespace SequencingApi.Application;
+
+/// <summary>Composition of the sequencing_api application layer (CQRS, behaviors, validators).</summary>
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        // Source-generated Mediator registration; handlers run in the request scope.
+        services.AddMediator(options => options.ServiceLifetime = ServiceLifetime.Scoped);
+
+        services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+        services.AddSingleton(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+
+        // Application-level request validators (FluentValidation). Auto-registers any
+        // AbstractValidator<TCommand> in this assembly; the ValidationBehavior runs them.
+        services.AddValidatorsFromAssembly(typeof(DependencyInjection).Assembly);
+
+        return services;
+    }
+}

--- a/src/SequencingApi/SequencingApi.Application/Features/Ingest/IngestRecordsCommand.cs
+++ b/src/SequencingApi/SequencingApi.Application/Features/Ingest/IngestRecordsCommand.cs
@@ -1,0 +1,40 @@
+using ErrorOr;
+using Mediator;
+using SequencingApi.Application.Abstractions.DataSource;
+
+namespace SequencingApi.Application.Features.Ingest;
+
+/// <summary>
+/// Command backing the ingestion entrypoint: read the data source and persist the records that
+/// validate. Returns an <see cref="IngestRecordsCommandResult"/> reporting failures, not just a count.
+/// </summary>
+public sealed record IngestRecordsCommand : ICommand<ErrorOr<IngestRecordsCommandResult>>;
+
+internal sealed class IngestRecordsCommandHandler
+    : ICommandHandler<IngestRecordsCommand, ErrorOr<IngestRecordsCommandResult>>
+{
+    private readonly ISequencingDataSource _source;
+
+    public IngestRecordsCommandHandler(ISequencingDataSource source)
+    {
+        _source = source;
+    }
+
+    public ValueTask<ErrorOr<IngestRecordsCommandResult>> Handle(
+        IngestRecordsCommand command,
+        CancellationToken cancellationToken)
+    {
+        // ponytail: no repository yet — the sequencing domain and persistence land with #30. For now
+        // the handler just reads the (stub) source and reports its counts; wire the repository save
+        // in the same shape as BiobankApi's ingestion handler when the aggregate exists.
+        var read = _source.ReadRecords();
+        if (read.IsError)
+        {
+            return ValueTask.FromResult<ErrorOr<IngestRecordsCommandResult>>(read.Errors);
+        }
+
+        var result = read.Value;
+        return ValueTask.FromResult<ErrorOr<IngestRecordsCommandResult>>(
+            new IngestRecordsCommandResult(result.RecordCount, result.Errors.Count, result.Errors));
+    }
+}

--- a/src/SequencingApi/SequencingApi.Application/Features/Ingest/IngestRecordsCommandResult.cs
+++ b/src/SequencingApi/SequencingApi.Application/Features/Ingest/IngestRecordsCommandResult.cs
@@ -1,0 +1,9 @@
+using SequencingApi.Application.Abstractions.DataSource;
+
+namespace SequencingApi.Application.Features.Ingest;
+
+/// <summary>
+/// The result of an <see cref="IngestRecordsCommand"/>: how many records were persisted, how many
+/// records failed, and the per-failure details so invalid records are reported, not silently dropped.
+/// </summary>
+public sealed record IngestRecordsCommandResult(int Ingested, int Failed, IReadOnlyList<RecordReadError> Errors);

--- a/src/SequencingApi/SequencingApi.Application/SequencingApi.Application.csproj
+++ b/src/SequencingApi/SequencingApi.Application/SequencingApi.Application.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SequencingApi.Application</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SequencingApi.Domain\SequencingApi.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ErrorOr" />
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="Mediator.Abstractions" />
+    <PackageReference Include="Mediator.SourceGenerator">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/SequencingApi/SequencingApi.Domain/Common/AggregateRoot.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Common/AggregateRoot.cs
@@ -1,0 +1,11 @@
+namespace SequencingApi.Domain.Common;
+
+/// <summary>
+/// Base for aggregate roots — the consistency boundary and single entry point for a cluster of
+/// entities. External code only ever holds a reference to the root; entities outside the cluster
+/// reference it by identity (<typeparamref name="TId"/>), never by object reference.
+/// </summary>
+public abstract class AggregateRoot<TId> : Entity<TId>
+    where TId : notnull
+{
+}

--- a/src/SequencingApi/SequencingApi.Domain/Common/Entity.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Common/Entity.cs
@@ -1,0 +1,25 @@
+namespace SequencingApi.Domain.Common;
+
+/// <summary>
+/// Base for domain entities: objects with a stable identity. Two entities of the same runtime type
+/// are equal when their <see cref="Id"/> is equal.
+/// </summary>
+public abstract class Entity<TId> : IEquatable<Entity<TId>>
+    where TId : notnull
+{
+    public required TId Id { get; init; }
+
+    public bool Equals(Entity<TId>? other) =>
+        other is not null
+        && GetType() == other.GetType()
+        && EqualityComparer<TId>.Default.Equals(Id, other.Id);
+
+    public override bool Equals(object? obj) => Equals(obj as Entity<TId>);
+
+    public override int GetHashCode() => HashCode.Combine(GetType(), Id);
+
+    public static bool operator ==(Entity<TId>? left, Entity<TId>? right) =>
+        left is null ? right is null : left.Equals(right);
+
+    public static bool operator !=(Entity<TId>? left, Entity<TId>? right) => !(left == right);
+}

--- a/src/SequencingApi/SequencingApi.Domain/Common/Identifiers.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Common/Identifiers.cs
@@ -1,0 +1,10 @@
+namespace SequencingApi.Domain.Common;
+
+/// <summary>A strongly-typed identifier wrapping a single string value.</summary>
+public interface IStronglyTypedId
+{
+    string Value { get; }
+}
+
+// ponytail: concrete ids land with the first sequencing aggregate (#30); the base type is here so
+// they drop in the same shape as BiobankApi (readonly record struct : IStronglyTypedId).

--- a/src/SequencingApi/SequencingApi.Domain/Common/ValueObject.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Common/ValueObject.cs
@@ -1,0 +1,4 @@
+namespace SequencingApi.Domain.Common;
+
+/// <summary>Base for value objects — immutable, identity-less descriptors compared by value.</summary>
+public abstract record ValueObject;

--- a/src/SequencingApi/SequencingApi.Domain/SequencingApi.Domain.csproj
+++ b/src/SequencingApi/SequencingApi.Domain/SequencingApi.Domain.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SequencingApi.Domain</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The persistence mapper reconstitutes aggregates via their internal initializer. -->
+    <InternalsVisibleTo Include="SequencingApi.Infrastructure" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ErrorOr" />
+  </ItemGroup>
+
+</Project>

--- a/src/SequencingApi/SequencingApi.Infrastructure/Configuration/SequencingOptions.cs
+++ b/src/SequencingApi/SequencingApi.Infrastructure/Configuration/SequencingOptions.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+
+namespace SequencingApi.Infrastructure.Configuration;
+
+/// <summary>
+/// Runtime configuration for the sequencing API, read from environment variables (the same shape the
+/// biobank service uses). Defaults keep the app runnable without a configured environment.
+/// </summary>
+public sealed class SequencingOptions
+{
+    public string PostgresUser { get; init; } = "postgres";
+    public string PostgresPassword { get; init; } = "postgres";
+    public string PostgresDb { get; init; } = "sequencing_api";
+    public string PostgresHost { get; init; } = "localhost";
+    public int PostgresPort { get; init; } = 5434;
+    public string SequencingHost { get; init; } = "0.0.0.0";
+    public int SequencingPort { get; init; } = 8002;
+    public string SequencingDataPath { get; init; } = "data/records";
+
+    public string ConnectionString =>
+        $"Host={PostgresHost};Port={PostgresPort};Database={PostgresDb};Username={PostgresUser};Password={PostgresPassword}";
+
+    public static SequencingOptions FromConfiguration(IConfiguration configuration)
+    {
+        var defaults = new SequencingOptions();
+        return new SequencingOptions
+        {
+            PostgresUser = configuration["POSTGRES_USER"] ?? defaults.PostgresUser,
+            PostgresPassword = configuration["POSTGRES_PASSWORD"] ?? defaults.PostgresPassword,
+            PostgresDb = configuration["POSTGRES_DB"] ?? defaults.PostgresDb,
+            PostgresHost = configuration["POSTGRES_HOST"] ?? defaults.PostgresHost,
+            PostgresPort = ParseInt(configuration["POSTGRES_PORT"], defaults.PostgresPort),
+            SequencingHost = configuration["SEQUENCING_HOST"] ?? defaults.SequencingHost,
+            SequencingPort = ParseInt(configuration["SEQUENCING_PORT"], defaults.SequencingPort),
+            SequencingDataPath = configuration["SEQUENCING_DATA_PATH"] ?? defaults.SequencingDataPath,
+        };
+    }
+
+    private static int ParseInt(string? raw, int fallback) =>
+        int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : fallback;
+}

--- a/src/SequencingApi/SequencingApi.Infrastructure/DataSource/StubSequencingDataSource.cs
+++ b/src/SequencingApi/SequencingApi.Infrastructure/DataSource/StubSequencingDataSource.cs
@@ -1,0 +1,20 @@
+using ErrorOr;
+using SequencingApi.Application.Abstractions.DataSource;
+
+namespace SequencingApi.Infrastructure.DataSource;
+
+/// <summary>
+/// Placeholder data source: reports zero records and no errors so the ingestion pipeline runs
+/// end-to-end while the service is still a scaffold.
+/// </summary>
+/// <remarks>
+/// ponytail: replace with the real reader (its own <c>*DataSource</c> under this namespace) once the
+/// sequencing data format is defined in #30 — mirror BiobankApi's <c>XmlExportParser</c>.
+/// </remarks>
+internal sealed class StubSequencingDataSource : ISequencingDataSource
+{
+    public string Name => "stub";
+
+    public ErrorOr<RecordReadResult> ReadRecords() =>
+        new RecordReadResult(RecordCount: 0, Errors: []);
+}

--- a/src/SequencingApi/SequencingApi.Infrastructure/DependencyInjection.cs
+++ b/src/SequencingApi/SequencingApi.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SequencingApi.Application.Abstractions.DataSource;
+using SequencingApi.Infrastructure.Configuration;
+using SequencingApi.Infrastructure.DataSource;
+using SequencingApi.Infrastructure.Persistence;
+
+namespace SequencingApi.Infrastructure;
+
+/// <summary>Composition of the sequencing_api infrastructure layer (EF Core, export source).</summary>
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var options = SequencingOptions.FromConfiguration(configuration);
+        services.AddSingleton(options);
+
+        services.AddDbContext<SequencingDbContext>(db => db.UseNpgsql(options.ConnectionString));
+
+        // The single data source for this facility; the ingestion handler reads it.
+        services.AddSingleton<ISequencingDataSource, StubSequencingDataSource>();
+
+        return services;
+    }
+}

--- a/src/SequencingApi/SequencingApi.Infrastructure/Persistence/SequencingDbContext.cs
+++ b/src/SequencingApi/SequencingApi.Infrastructure/Persistence/SequencingDbContext.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace SequencingApi.Infrastructure.Persistence;
+
+/// <summary>EF Core context for the sequencing_api database.</summary>
+/// <remarks>
+/// ponytail: no DbSets yet — the sequencing schema and its first migration land with #30. The context
+/// exists so the host, options and design-time factory are wired in the same shape as BiobankApi.
+/// </remarks>
+public sealed class SequencingDbContext : DbContext
+{
+    public SequencingDbContext(DbContextOptions<SequencingDbContext> options) : base(options)
+    {
+    }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        // Source dates are zone-less calendar values; timestamp-without-time-zone accepts
+        // DateTimeKind.Unspecified, unlike timestamptz which only accepts UTC.
+        configurationBuilder.Properties<DateTime>().HaveColumnType("timestamp without time zone");
+    }
+}

--- a/src/SequencingApi/SequencingApi.Infrastructure/Persistence/SequencingDbContextFactory.cs
+++ b/src/SequencingApi/SequencingApi.Infrastructure/Persistence/SequencingDbContextFactory.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace SequencingApi.Infrastructure.Persistence;
+
+/// <summary>
+/// Design-time factory so <c>dotnet ef migrations</c> can build the context without the running
+/// host or a live database. The connection string here is a placeholder used only at design time.
+/// </summary>
+internal sealed class SequencingDbContextFactory : IDesignTimeDbContextFactory<SequencingDbContext>
+{
+    public SequencingDbContext CreateDbContext(string[] args)
+    {
+        var options = new DbContextOptionsBuilder<SequencingDbContext>()
+            .UseNpgsql("Host=localhost;Port=5434;Database=sequencing_api;Username=postgres;Password=postgres")
+            .Options;
+
+        return new SequencingDbContext(options);
+    }
+}

--- a/src/SequencingApi/SequencingApi.Infrastructure/SequencingApi.Infrastructure.csproj
+++ b/src/SequencingApi/SequencingApi.Infrastructure/SequencingApi.Infrastructure.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SequencingApi.Infrastructure</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SequencingApi.Application\SequencingApi.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SequencingApi.IntegrationTests" />
+    <InternalsVisibleTo Include="SequencingApi.UnitTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+  </ItemGroup>
+
+</Project>

--- a/src/SequencingApi/SequencingApi.Web/Contracts/HealthResponse.cs
+++ b/src/SequencingApi/SequencingApi.Web/Contracts/HealthResponse.cs
@@ -1,0 +1,4 @@
+namespace SequencingApi.Web.Contracts;
+
+/// <summary>Response shape for <c>GET /health</c>.</summary>
+public sealed record HealthResponse(string Status);

--- a/src/SequencingApi/SequencingApi.Web/Dockerfile
+++ b/src/SequencingApi/SequencingApi.Web/Dockerfile
@@ -1,0 +1,14 @@
+# Build from the repo root as the context (central package management + project refs).
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet restore src/SequencingApi/SequencingApi.Web/SequencingApi.Web.csproj
+RUN dotnet publish src/SequencingApi/SequencingApi.Web/SequencingApi.Web.csproj \
+    -c Release -o /app --no-restore /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 8002
+# Runs the HTTP API (ingestion runs on the weekly Quartz schedule and via POST /admin/ingest).
+ENTRYPOINT ["dotnet", "SequencingApi.Web.dll"]

--- a/src/SequencingApi/SequencingApi.Web/Endpoints/AdminEndpoints.cs
+++ b/src/SequencingApi/SequencingApi.Web/Endpoints/AdminEndpoints.cs
@@ -1,0 +1,22 @@
+using Mediator;
+using SequencingApi.Application.Features.Ingest;
+using SequencingApi.Web.Http;
+
+namespace SequencingApi.Web.Endpoints;
+
+internal static class AdminEndpoints
+{
+    public static IEndpointRouteBuilder MapAdminEndpoints(this IEndpointRouteBuilder app)
+    {
+        // Manual ingestion trigger for testing on a running server: runs the same pipeline the
+        // weekly Quartz job runs, and returns the ingest summary. Ingestion is idempotent.
+        app.MapPost("/admin/ingest", async (ISender sender, CancellationToken cancellationToken) =>
+        {
+            var result = await sender.Send(new IngestRecordsCommand(), cancellationToken);
+            return result.Match(success => Results.Ok(success), ErrorResults.Problem);
+        })
+        .WithTags("admin");
+
+        return app;
+    }
+}

--- a/src/SequencingApi/SequencingApi.Web/Endpoints/HealthEndpoints.cs
+++ b/src/SequencingApi/SequencingApi.Web/Endpoints/HealthEndpoints.cs
@@ -1,0 +1,14 @@
+using SequencingApi.Web.Contracts;
+
+namespace SequencingApi.Web.Endpoints;
+
+internal static class HealthEndpoints
+{
+    public static IEndpointRouteBuilder MapHealthEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/health", () => Results.Ok(new HealthResponse("ok")))
+            .WithTags("health");
+
+        return app;
+    }
+}

--- a/src/SequencingApi/SequencingApi.Web/Http/ErrorResults.cs
+++ b/src/SequencingApi/SequencingApi.Web/Http/ErrorResults.cs
@@ -1,0 +1,35 @@
+using ErrorOr;
+
+namespace SequencingApi.Web.Http;
+
+/// <summary>Maps an <see cref="ErrorOr"/> failure list to an HTTP result at the API edge.</summary>
+internal static class ErrorResults
+{
+    public static IResult Problem(List<Error> errors)
+    {
+        if (errors.Count == 0)
+        {
+            return Results.Problem();
+        }
+
+        if (errors.TrueForAll(error => error.Type == ErrorType.Validation))
+        {
+            var failures = errors
+                .GroupBy(error => error.Code)
+                .ToDictionary(group => group.Key, group => group.Select(error => error.Description).ToArray());
+            return Results.ValidationProblem(failures);
+        }
+
+        var first = errors[0];
+        var statusCode = first.Type switch
+        {
+            ErrorType.NotFound => StatusCodes.Status404NotFound,
+            ErrorType.Conflict => StatusCodes.Status409Conflict,
+            ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
+            ErrorType.Forbidden => StatusCodes.Status403Forbidden,
+            _ => StatusCodes.Status500InternalServerError,
+        };
+
+        return Results.Problem(detail: first.Description, statusCode: statusCode);
+    }
+}

--- a/src/SequencingApi/SequencingApi.Web/Program.cs
+++ b/src/SequencingApi/SequencingApi.Web/Program.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Quartz;
+using SequencingApi.Application;
+using SequencingApi.Infrastructure;
+using SequencingApi.Infrastructure.Persistence;
+using SequencingApi.Web.Endpoints;
+using SequencingApi.Web.Scheduling;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+    options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower);
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddOpenApi();
+
+// Weekly in-process ingestion via Quartz (OS-independent: identical on Windows and Linux). The cron
+// is overridable with SEQUENCING_INGEST_CRON for testing; POST /admin/ingest triggers a run on demand.
+// Disabled with DisableScheduler=true: integration tests spin up many hosts in one process, and
+// Quartz's global static logging provider captures (then over-disposes) a per-host LoggerFactory.
+if (!builder.Configuration.GetValue<bool>("DisableScheduler"))
+{
+    var ingestCron = builder.Configuration["SEQUENCING_INGEST_CRON"] ?? "0 0 17 ? * SUN"; // Sundays 17:00 UTC
+    builder.Services.AddQuartz(quartz =>
+    {
+        var jobKey = new JobKey("ingestion");
+        quartz.AddJob<IngestionJob>(jobKey);
+        quartz.AddTrigger(trigger => trigger.ForJob(jobKey).WithCronSchedule(ingestCron));
+    });
+    builder.Services.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+}
+
+var app = builder.Build();
+
+// Apply pending migrations when explicitly asked (set by the container; tests leave it unset).
+if (string.Equals(Environment.GetEnvironmentVariable("RUN_MIGRATIONS"), "true", StringComparison.OrdinalIgnoreCase))
+{
+    using var migrationScope = app.Services.CreateScope();
+    await migrationScope.ServiceProvider.GetRequiredService<SequencingDbContext>().Database.MigrateAsync();
+}
+
+app.MapOpenApi();
+app.MapHealthEndpoints();
+app.MapAdminEndpoints();
+
+await app.RunAsync();
+return 0;
+
+/// <summary>Exposed so the integration tests can host the app via <c>WebApplicationFactory</c>.</summary>
+public partial class Program;

--- a/src/SequencingApi/SequencingApi.Web/Scheduling/IngestionJob.cs
+++ b/src/SequencingApi/SequencingApi.Web/Scheduling/IngestionJob.cs
@@ -1,0 +1,36 @@
+using Mediator;
+using Quartz;
+using SequencingApi.Application.Features.Ingest;
+
+namespace SequencingApi.Web.Scheduling;
+
+/// <summary>
+/// Quartz job that runs the sequencing ingestion pipeline on the configured schedule (weekly by
+/// default). Each run dispatches <see cref="IngestRecordsCommand"/> and logs the summary. Failures
+/// are logged, never thrown, so a bad run does not stop the scheduler from firing again.
+/// </summary>
+[DisallowConcurrentExecution]
+internal sealed class IngestionJob : IJob
+{
+    private readonly ISender _sender;
+    private readonly ILogger<IngestionJob> _logger;
+
+    public IngestionJob(ISender sender, ILogger<IngestionJob> logger)
+    {
+        _sender = sender;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        var result = await _sender.Send(new IngestRecordsCommand(), context.CancellationToken);
+        result.Switch(
+            success => _logger.LogInformation(
+                "Scheduled ingestion complete: {Ingested} ingested, {Failed} failed.",
+                success.Ingested,
+                success.Failed),
+            errors => _logger.LogError(
+                "Scheduled ingestion failed: {Errors}",
+                string.Join("; ", errors.Select(error => error.Description))));
+    }
+}

--- a/src/SequencingApi/SequencingApi.Web/SequencingApi.Web.csproj
+++ b/src/SequencingApi/SequencingApi.Web/SequencingApi.Web.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <RootNamespace>SequencingApi.Web</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SequencingApi.Infrastructure\SequencingApi.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SequencingApi.IntegrationTests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Quartz.Extensions.Hosting" />
+  </ItemGroup>
+
+</Project>

--- a/src/SequencingApi/SequencingApi.Web/appsettings.json
+++ b/src/SequencingApi/SequencingApi.Web/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/SequencingApi.IntegrationTests/ApiTests.cs
+++ b/tests/SequencingApi.IntegrationTests/ApiTests.cs
@@ -8,25 +8,28 @@ using Xunit;
 
 namespace SequencingApi.IntegrationTests;
 
-public sealed class ApiTests
+public sealed class ApiTests : IDisposable
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
     };
 
-    private static HttpClient CreateClient()
-    {
-        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
-            builder.UseSetting("DisableScheduler", "true"));
+    private static readonly WebApplicationFactory<Program> Factory = new WebApplicationFactory<Program>()
+        .WithWebHostBuilder(builder => builder.UseSetting("DisableScheduler", "true"));
 
-        return factory.CreateClient();
+    private static readonly HttpClient Client = Factory.CreateClient();
+
+    public void Dispose()
+    {
+        Client.Dispose();
+        Factory.Dispose();
     }
 
     [Fact]
     public async Task HealthReturnsOk()
     {
-        var response = await CreateClient().GetAsync("/health");
+        var response = await Client.GetAsync("/health");
 
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadFromJsonAsync<HealthResponse>(JsonOptions);
@@ -36,7 +39,7 @@ public sealed class ApiTests
     [Fact]
     public async Task IngestReturnsZeroCounts()
     {
-        var response = await CreateClient().PostAsync("/admin/ingest", content: null);
+        var response = await Client.PostAsync("/admin/ingest", content: null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<IngestRecordsCommandResult>(JsonOptions);

--- a/tests/SequencingApi.IntegrationTests/ApiTests.cs
+++ b/tests/SequencingApi.IntegrationTests/ApiTests.cs
@@ -1,0 +1,47 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using SequencingApi.Application.Features.Ingest;
+using SequencingApi.Web.Contracts;
+using Xunit;
+
+namespace SequencingApi.IntegrationTests;
+
+public sealed class ApiTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    private static HttpClient CreateClient()
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.UseSetting("DisableScheduler", "true"));
+
+        return factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task HealthReturnsOk()
+    {
+        var response = await CreateClient().GetAsync("/health");
+
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<HealthResponse>(JsonOptions);
+        Assert.Equal("ok", body!.Status);
+    }
+
+    [Fact]
+    public async Task IngestReturnsZeroCounts()
+    {
+        var response = await CreateClient().PostAsync("/admin/ingest", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<IngestRecordsCommandResult>(JsonOptions);
+        Assert.Equal(0, body!.Ingested);
+        Assert.Equal(0, body.Failed);
+        Assert.Empty(body.Errors);
+    }
+}

--- a/tests/SequencingApi.IntegrationTests/ApiTests.cs
+++ b/tests/SequencingApi.IntegrationTests/ApiTests.cs
@@ -1,35 +1,31 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
 using SequencingApi.Application.Features.Ingest;
 using SequencingApi.Web.Contracts;
 using Xunit;
 
 namespace SequencingApi.IntegrationTests;
 
-public sealed class ApiTests : IDisposable
+public sealed class ApiTests : IClassFixture<SequencingWebApplicationFactory>
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
     };
 
-    private static readonly WebApplicationFactory<Program> Factory = new WebApplicationFactory<Program>()
-        .WithWebHostBuilder(builder => builder.UseSetting("DisableScheduler", "true"));
+    private readonly HttpClient _client;
 
-    private static readonly HttpClient Client = Factory.CreateClient();
-
-    public void Dispose()
+    public ApiTests(SequencingWebApplicationFactory factory)
     {
-        Client.Dispose();
-        Factory.Dispose();
+        // The factory owns and disposes the client when xUnit disposes the shared fixture.
+        _client = factory.CreateClient();
     }
 
     [Fact]
     public async Task HealthReturnsOk()
     {
-        var response = await Client.GetAsync("/health");
+        var response = await _client.GetAsync("/health");
 
         response.EnsureSuccessStatusCode();
         var body = await response.Content.ReadFromJsonAsync<HealthResponse>(JsonOptions);
@@ -39,7 +35,7 @@ public sealed class ApiTests : IDisposable
     [Fact]
     public async Task IngestReturnsZeroCounts()
     {
-        var response = await Client.PostAsync("/admin/ingest", content: null);
+        var response = await _client.PostAsync("/admin/ingest", content: null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<IngestRecordsCommandResult>(JsonOptions);

--- a/tests/SequencingApi.IntegrationTests/SequencingApi.IntegrationTests.csproj
+++ b/tests/SequencingApi.IntegrationTests/SequencingApi.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SequencingApi.IntegrationTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SequencingApi\SequencingApi.Infrastructure\SequencingApi.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\SequencingApi\SequencingApi.Web\SequencingApi.Web.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/SequencingApi.IntegrationTests/SequencingWebApplicationFactory.cs
+++ b/tests/SequencingApi.IntegrationTests/SequencingWebApplicationFactory.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace SequencingApi.IntegrationTests;
+
+/// <summary>
+/// Hosts the API for integration tests with the Quartz scheduler disabled (many hosts share one
+/// process). Shared across a test class via <see cref="Xunit.IClassFixture{TFixture}"/> and disposed
+/// once by xUnit, so no per-test factory is created or leaked.
+/// </summary>
+public sealed class SequencingWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder) =>
+        builder.UseSetting("DisableScheduler", "true");
+}

--- a/tests/SequencingApi.UnitTests/SequencingApi.UnitTests.csproj
+++ b/tests/SequencingApi.UnitTests/SequencingApi.UnitTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>SequencingApi.UnitTests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SequencingApi\SequencingApi.Application\SequencingApi.Application.csproj" />
+    <ProjectReference Include="..\..\src\SequencingApi\SequencingApi.Domain\SequencingApi.Domain.csproj" />
+    <!-- For unit-testing the internal data source. -->
+    <ProjectReference Include="..\..\src\SequencingApi\SequencingApi.Infrastructure\SequencingApi.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/SequencingApi.UnitTests/StubDataSourceTests.cs
+++ b/tests/SequencingApi.UnitTests/StubDataSourceTests.cs
@@ -1,0 +1,19 @@
+using SequencingApi.Infrastructure.DataSource;
+using Xunit;
+
+namespace SequencingApi.UnitTests;
+
+public sealed class StubDataSourceTests
+{
+    [Fact]
+    public void ReadRecordsReturnsZeroRecordsAndNoErrors()
+    {
+        var source = new StubSequencingDataSource();
+
+        var result = source.ReadRecords();
+
+        Assert.False(result.IsError);
+        Assert.Equal(0, result.Value.RecordCount);
+        Assert.Empty(result.Value.Errors);
+    }
+}


### PR DESCRIPTION
Closes #52.

Scaffolds `src/SequencingApi/` as a sibling of `biobank_api`: same Clean-Architecture layering, dependencies, tooling, and in-process Quartz ingestion. **Host-only stub** — no sequencing domain aggregate, repository, or EF migration yet; those land with #30. The stub data source reports zero records so the ingestion pipeline runs end-to-end. Search for `ponytail:` to find the spots to fill in.

## What's here
- **Four projects** `SequencingApi.{Domain,Application,Infrastructure,Web}` (Web → Infrastructure → Application → Domain), wired into `DataCatalogueUpload.slnx` and central package management.
- **Application**: `IngestRecordsCommand` + handler, `ISequencingDataSource` port (`RecordReadResult`/`RecordReadError`), Mediator + FluentValidation behaviors.
- **Infrastructure**: `SequencingDbContext` (no entities yet), design-time factory, `SequencingOptions` (env config), `StubSequencingDataSource`.
- **Web host**: `GET /health`, `POST /admin/ingest`, weekly Quartz `IngestionJob` (disable-able via `DisableScheduler`), migrate-on-boot.
- **Tests**: unit (stub source) + integration (`/health`, `/admin/ingest` over `WebApplicationFactory`).
- **Deploy**: Dockerfile (port 8002) + `sequencing-db`/`sequencing-api` in `compose.prod.yml` (Postgres 5434).
- **Docs & skills**: README/AGENTS/ARCHITECTURE/DEVELOPMENT + a service README; `dotnet-dev`/`testing` skills updated for three services.

## Acceptance criteria (#52)
- [x] Four projects added with correct layer references
- [x] Builds, formats, and `dotnet test` green from a stub
- [x] Web host boots with a health endpoint; Quartz job + `POST /admin/ingest` stubbed (disable-able for tests)
- [x] README documents setup and running locally

## Verification
- `dotnet build DataCatalogueUpload.slnx -c Release` → 0 errors
- `dotnet format DataCatalogueUpload.slnx --verify-no-changes` → clean
- `dotnet test DataCatalogueUpload.slnx` → 124 passed, 0 failed (3 new Sequencing tests)
- Integration test boots the host: `/health` → 200, `POST /admin/ingest` → `{ingested:0,failed:0,errors:[]}`

Part of #30. Reviewed as 9 focused commits (one per project, solution wiring, tests, docs, skills, docker/compose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)