### PR TITLE
feat(domain): define the Sequencing domain model

### DIFF
--- a/.claude/skills/dotnet-dev/SKILL.md
+++ b/.claude/skills/dotnet-dev/SKILL.md
@@ -14,7 +14,7 @@ and validate with `dotnet format` + `dotnet build` before finishing.
 ```
 src/
 ├── BiobankApi/     BiobankApi.{Domain,Application,Infrastructure,Web}
-├── SequencingApi/  SequencingApi.{Domain,Application,Infrastructure,Web}   (scaffold - stub host, no domain/migration yet)
+├── SequencingApi/  SequencingApi.{Domain,Application,Infrastructure,Web}   (domain landed; stub ingestion, no repository/migration yet)
 └── Uploader/       Uploader.{Domain,Application,Infrastructure,Host}
 ```
 

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -11,7 +11,7 @@ Tests live under `tests/`, two projects per service - **unit** and **integration
 tests/
 ├── BiobankApi.UnitTests             DomainModelsTests (aggregates/factories), XmlPatientReaderTests (pure XML->domain)
 ├── BiobankApi.IntegrationTests      ApiTests, RepositoryTests, MapperTests, XmlValueReaderTests, XmlExportParserTests
-├── SequencingApi.UnitTests          StubDataSourceTests (scaffold; grows with #30)
+├── SequencingApi.UnitTests          DomainModelsTests, NormalizationTests (sequencing aggregates/factories), StubDataSourceTests
 ├── SequencingApi.IntegrationTests   ApiTests (health + POST /admin/ingest over WebApplicationFactory)
 ├── Uploader.UnitTests               FingerprintSyncPlannerTests, FingerprintTests, SourceMapperTests, RunCatalogueSyncHandlerTests
 └── Uploader.IntegrationTests        SyncStateRepositoryTests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Guidance for AI coding agents (primarily Claude Code) working in this repository
 
 - **uploader** (`src/Uploader`) - a scheduled, one-shot sync job. For each patient it reads from four source APIs (biobank, radiology, sequencing, WSI), aggregates the data into one FAIR Genomes-shaped patient record, compares it against fingerprints stored in PostgreSQL, and upserts/deletes records in a central data catalogue API.
 - **biobank_api** (`src/BiobankApi`) - a source API service that parses biobank XML exports and serves the patient/sample/clinical endpoints the uploader consumes.
-- **sequencing_api** (`src/SequencingApi`) - source API service for sequencing data. Currently a **scaffold** (host + stub ingestion; no domain aggregate or EF migration yet - those land with #30). Same layering and in-process Quartz ingestion as biobank_api.
+- **sequencing_api** (`src/SequencingApi`) - source API service for sequencing data. Domain model landed (#54); ingestion is still stubbed and there is no repository or EF migration yet (those land with #55/#56). Same layering and in-process Quartz ingestion as biobank_api.
 
 Read [`ARCHITECTURE.md`](ARCHITECTURE.md) for the data flow and layering, and [`DEVELOPMENT.md`](DEVELOPMENT.md) for setup and local run instructions.
 
@@ -34,7 +34,7 @@ Dependency direction per service: `Web`/`Host` -> `Infrastructure` -> `Applicati
 
 ## Architecture (both services)
 
-- **Clean Architecture + DDD.** Domain holds aggregates (`PatientAggregate` in both services), value objects, and invariants. The uploader adds the domain service `ISyncPlanner` (`FingerprintSyncPlanner`); change detection is aggregate behaviour (`ComputeFingerprint()` over `Fingerprint.Of(...)`). The biobank has no domain service - XML text cleaning lives in infrastructure (`XmlValueReader`). Domain has no I/O and no framework dependencies.
+- **Clean Architecture + DDD.** Domain holds aggregates (`PatientAggregate` in biobank_api and the uploader; `SampleAggregate`/`SequencingRunAggregate`/`PanelAggregate` in sequencing_api), value objects, and invariants. The uploader adds the domain service `ISyncPlanner` (`FingerprintSyncPlanner`); change detection is aggregate behaviour (`ComputeFingerprint()` over `Fingerprint.Of(...)`). The biobank has no domain service - XML text cleaning lives in infrastructure (`XmlValueReader`). Domain has no I/O and no framework dependencies.
 - **CQRS via Mediator.** Every use case is a `Command`/`Query` with a handler in `*.Application/Features/...`, dispatched through the free `Mediator` source generator (`ISender`). Handlers return `ErrorOr<T>`. A non-trivial result type is named after its request - `<Command>Result` (e.g. `RunCatalogueSyncCommandResult`, `IngestExportsCommandResult`) - in the same `Features/` folder.
 - **Pipeline behaviors** (`*.Application/Behaviors`): `LoggingBehavior` wraps each request; `ValidationBehavior` runs any FluentValidation `AbstractValidator<TCommand>` (auto-registered via `AddValidatorsFromAssembly`) and short-circuits to an `ErrorOr` validation error before the handler. Application-level request validation lives here; domain invariants stay in the aggregate `Create(...)` factories. (Current commands are parameterless, so no validators exist yet.)
 - **Ports are interfaces** in `*.Application/Abstractions`, implemented in `*.Infrastructure` (EF Core repositories, the biobank XML parser, the uploader's typed `HttpClient` gateways).
@@ -46,7 +46,7 @@ EF Core (Npgsql) + LINQ-to-XML (`System.Xml.Linq`). Domain `PatientAggregate` wi
 
 ## sequencing_api
 
-**Scaffold** mirroring biobank_api (host + stub ingestion; the sequencing domain, repository and first EF migration land with #30). Domain has only the `Common/` base types. Ingestion reads the `ISequencingDataSource` port (`Abstractions/DataSource/`); the current `StubSequencingDataSource` reports zero records so `IngestRecordsCommand` runs end-to-end. Host `SequencingApi.Web` runs the Minimal API (`GET /health`, `POST /admin/ingest`) and a **weekly Quartz job** (`IngestionJob`). Config via env vars (`POSTGRES_*`, `SEQUENCING_*` incl. `SEQUENCING_INGEST_CRON`); see `SequencingOptions`. Search for `ponytail:` to find the spots to fill in.
+Mirrors biobank_api (host + stub ingestion; the repository and first EF migration land with #55). Domain is a biobank-agnostic sequencing model derived from [`docs/sequencing-data-report.md`](docs/sequencing-data-report.md) §4, with **three aggregate roots**: `SampleAggregate` (`Samples/`, keyed by an opaque `external_id` + `IdScheme`, owning `RunSample` -> `LibraryPreparation`/`SequencingFile`/`Analysis`), `SequencingRunAggregate` (`Runs/`, + `ReadDefinition`) and `PanelAggregate` (`Panels/`). Runs and panels are shared by many samples, so they are referenced by id, never embedded. `QualityMetrics` and the enums (`SampleType`, `FileRole`, `AnalysisType`, `QualityVerdict`) sit at the Domain root. **Individual variant records are deliberately not modelled** - the catalogue consumes none of them; analyses reference their calls as files (`FileRole.Vcf`/`VariantReport`) and summarise them in `QualityMetrics`. **`QualityMetrics` attaches to `Analysis` only** - every metric in it is computed by the pipeline, so the run carries a plain `PercentageQ30` instead and `RunSample` carries no quality at all. Invariants **and value cleaning** live in the `Create(...)` factories via the internal `Common/Normalize` helper (trim/collapse/case-fold/symbol lists); source decoding - text encoding, decimal commas, panel alias matching - stays in Infrastructure. Ingestion reads the `ISequencingDataSource` port (`Abstractions/DataSource/`); the current `StubSequencingDataSource` reports zero records so `IngestRecordsCommand` runs end-to-end. Host `SequencingApi.Web` runs the Minimal API (`GET /health`, `POST /admin/ingest`) and a **weekly Quartz job** (`IngestionJob`). Config via env vars (`POSTGRES_*`, `SEQUENCING_*` incl. `SEQUENCING_INGEST_CRON`); see `SequencingOptions`. Search for `ponytail:` to find the remaining spots to fill in.
 
 ## uploader
 
@@ -65,7 +65,7 @@ dotnet format DataCatalogueUpload.slnx --verify-no-changes   # lint/format (drop
 # EF Core migrations
 dotnet ef migrations add <Name> --project src/BiobankApi/BiobankApi.Infrastructure --startup-project src/BiobankApi/BiobankApi.Web -o Persistence/Migrations
 dotnet ef migrations add <Name> --project src/Uploader/Uploader.Infrastructure   --startup-project src/Uploader/Uploader.Host    -o Persistence/Migrations
-# sequencing_api has no entities yet (#30); once it does, the same command with SequencingApi paths applies.
+# sequencing_api has a domain model but no EF entities yet (#55); once it does, the same command with SequencingApi paths applies.
 ```
 
 ## Conventions

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture Overview
 
 > This repository is a **.NET solution** (`DataCatalogueUpload.slnx`). The services - the `uploader`
-> sync job and the source APIs (`biobank_api`, plus the `sequencing_api` scaffold) - live under `src/`.
+> sync job and the source APIs (`biobank_api` and `sequencing_api`) - live under `src/`.
 > This document describes the **uploader** and the end-to-end data flow; each service follows the same
 > Clean Architecture layering. See [`AGENTS.md`](AGENTS.md) for the solution layout.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,7 +40,7 @@ Configuration is read from **environment variables** (no `.env` files are tracke
 **biobank_api:** `POSTGRES_USER|PASSWORD|DB|HOST|PORT`, `BIOBANK_HOST|PORT`, `BIOBANK_XML_EXPORT_PATH`.
 For local runs against `biobank-db`, set `POSTGRES_PORT=5433`.
 
-**sequencing_api** (scaffold): `POSTGRES_USER|PASSWORD|DB|HOST|PORT`, `SEQUENCING_HOST|PORT`,
+**sequencing_api** (ingestion still stubbed): `POSTGRES_USER|PASSWORD|DB|HOST|PORT`, `SEQUENCING_HOST|PORT`,
 `SEQUENCING_DATA_PATH`, `SEQUENCING_INGEST_CRON`. For local runs against `sequencing-db`, set
 `POSTGRES_PORT=5434`.
 
@@ -66,8 +66,8 @@ dotnet ef migrations add <Name> \
   --output-dir Persistence/Migrations
 ```
 
-The **sequencing_api** has no entities yet (#30); the same commands with its `SequencingApi` paths
-apply once it does.
+The **sequencing_api** has a domain model but no EF entities yet (#55); the same commands with its
+`SequencingApi` paths apply once it does.
 
 At runtime the **uploader** applies migrations on startup; the **biobank_api** and **sequencing_api**
 apply them when `RUN_MIGRATIONS=true` is set (the container sets it; tests leave it unset).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ services it reads from. The solution is [`DataCatalogueUpload.slnx`](DataCatalog
 |---------|----------|------------|
 | uploader | [`src/Uploader`](src/Uploader) | Scheduled, one-shot sync job: aggregates per-patient data from the source APIs and upserts it into the data catalogue. |
 | biobank_api | [`src/BiobankApi`](src/BiobankApi) | Source API service: parses biobank XML exports and serves the patient/sample/clinical endpoints the uploader consumes. |
-| sequencing_api | [`src/SequencingApi`](src/SequencingApi) | Source API service for sequencing data (scaffold — domain and endpoints land with #30). Same Clean Architecture layering and in-process Quartz ingestion as biobank_api. |
+| sequencing_api | [`src/SequencingApi`](src/SequencingApi) | Source API service for sequencing data (domain model landed; persistence and endpoints land with #55/#58). Same Clean Architecture layering and in-process Quartz ingestion as biobank_api. |
 
 Each service is its own set of projects (Domain / Application / Infrastructure / host) following
 **Clean Architecture + DDD**: a rich domain with aggregates and domain services that enforce their

--- a/src/SequencingApi/README.md
+++ b/src/SequencingApi/README.md
@@ -7,15 +7,54 @@ and invariant factories, a CQRS application layer dispatched through the
 an ASP.NET Core Minimal API host. Ingestion runs in-process in the Web host (weekly Quartz job +
 `POST /admin/ingest`).
 
-> **Status: scaffold.** No sequencing domain aggregate, repository or EF migration exists yet — those
-> land with feature work under #30. The stub ingestion source reports zero records so the pipeline runs
-> end-to-end. Search the tree for `ponytail:` to find the exact spots to fill in.
+> **Status: domain model only.** The sequencing domain landed with #54; the repository and first EF
+> migration land with #55, and the real export reader with #56. The stub ingestion source reports zero
+> records so the pipeline runs end-to-end. Search the tree for `ponytail:` to find the remaining spots
+> to fill in.
+
+## Domain model
+
+Derived from [`docs/sequencing-data-report.md`](../../docs/sequencing-data-report.md) §4 and kept
+**biobank-agnostic** — the first source's folder layout, vendor report formats and panel-matching rules
+all stay in the ingestion adapter.
+
+Three aggregate roots, referencing each other by identity only:
+
+```
+SampleAggregate (SampleId = opaque external_id, + IdScheme)   PanelAggregate (PanelId)
+  └── RunSample : Entity<SequencingRunId>                          ▲
+        ├── LibraryPreparation?  ────────── PanelId ───────────────┘
+        ├── SequencingFile[]  (by FileRole)
+        └── Analysis[]                       SequencingRunAggregate (SequencingRunId)
+              ├── SequencingFile[]             ├── ReadDefinition[]
+              └── QualityMetrics?              └── PercentageQ30
+```
+
+**Individual variant records are deliberately not modelled.** Nothing in the catalogue path consumes
+them, and they would be by far the largest table in the service. An analysis references its variant
+calls as files (`FileRole.Vcf`, `FileRole.VcfFiltered`, `FileRole.VariantReport`) and summarises them
+in `QualityMetrics` (`TotalVariants`, `TsTvRatio`, homozygous/heterozygous split). Add a `Variant`
+entity the day something actually queries variants.
+
+**`QualityMetrics` hangs off `Analysis` only.** Every metric in it — coverage, read counts, on-target
+rate, variant summaries — is computed by the analysis pipeline, not by the instrument. A run measures
+exactly one quality number, so it carries a plain `PercentageQ30` property instead of a
+mostly-null metrics object, and `RunSample` carries none at all.
+
+A run is shared by roughly a dozen samples and a panel by hundreds, so both are their own root rather
+than being embedded. `RunSample` is identified by the run it belongs to — a sample is sequenced at most
+once per run, and `SampleAggregate.Create` rejects duplicate run ids so that stays true.
+
+Invariants **and value cleaning** live in the `Create(...)` factories (`ErrorOr<T>`, first failure
+wins), sharing the internal `Common/Normalize` helper. Cleaning is limited to already-typed values —
+trimming, whitespace collapsing, case folding, chromosome and gene-symbol canonicalisation. Turning
+source text into numbers or dates is decoding, not domain logic, and stays in Infrastructure.
 
 ## Projects
 
 | Layer | Project | Notes |
 |-------|---------|-------|
-| Domain | `SequencingApi.Domain` | `Common/` base types only (Entity, AggregateRoot, ValueObject, `IStronglyTypedId`). |
+| Domain | `SequencingApi.Domain` | `Samples/`, `Runs/`, `Panels/` aggregates; `QualityMetrics` + `Enums.cs` at the root; `Common/` base types, typed ids and `Normalize`. |
 | Application | `SequencingApi.Application` | `IngestRecordsCommand` + handler, `ISequencingDataSource` port, Mediator/FluentValidation wiring. |
 | Infrastructure | `SequencingApi.Infrastructure` | `SequencingDbContext` (no DbSets yet), `SequencingOptions`, design-time factory, `StubSequencingDataSource`. |
 | Web | `SequencingApi.Web` | Minimal-API host: `GET /health`, `POST /admin/ingest`, Quartz `IngestionJob`. |

--- a/src/SequencingApi/SequencingApi.Domain/Common/Identifiers.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Common/Identifiers.cs
@@ -6,5 +6,33 @@ public interface IStronglyTypedId
     string Value { get; }
 }
 
-// ponytail: concrete ids land with the first sequencing aggregate (#30); the base type is here so
-// they drop in the same shape as BiobankApi (readonly record struct : IStronglyTypedId).
+/// <summary>
+/// Identity of a sequenced sample — the opaque <c>external_id</c> the source biobank knows it by,
+/// paired with an <c>id_scheme</c> on the aggregate that says which naming system it belongs to.
+/// MMCI's instance is the pseudonymized predictive number (<c>mmci_predictive_&lt;uuid&gt;</c>).
+/// The surrogate <c>sample_id</c> primary key proposed by the data report is a persistence concern
+/// and is not modelled here.
+/// </summary>
+public readonly record struct SampleId(string Value) : IStronglyTypedId
+{
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Identity of a sequencing run / flowcell. MMCI's instance is the Illumina run-folder name
+/// (<c>&lt;YYMMDD&gt;_&lt;instrument&gt;_&lt;run#&gt;_&lt;flowcell&gt;</c>). The same run id can be
+/// discovered more than once in a source tree, so it doubles as the de-duplication key.
+/// </summary>
+public readonly record struct SequencingRunId(string Value) : IStronglyTypedId
+{
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Identity of a target panel — the gene set and target regions a sample was enriched for. Shared
+/// by many samples, hence its own aggregate referenced by id.
+/// </summary>
+public readonly record struct PanelId(string Value) : IStronglyTypedId
+{
+    public override string ToString() => Value;
+}

--- a/src/SequencingApi/SequencingApi.Domain/Common/Normalize.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Common/Normalize.cs
@@ -1,0 +1,54 @@
+namespace SequencingApi.Domain.Common;
+
+/// <summary>
+/// Text canonicalisation shared by the domain <c>Create(...)</c> factories, so the same raw value
+/// always becomes the same domain value regardless of which source produced it.
+/// </summary>
+/// <remarks>
+/// Deliberately limited to cleaning values that are <em>already typed</em>: trimming, whitespace
+/// collapsing, case folding. Turning source text into numbers or dates is decoding, not domain
+/// logic — the sequencing data report assigns every such quirk (Windows-1250 encoding, decimal
+/// commas, multi-allelic packing, the versioned Libraries CSV, experiment-name alias tables) to the
+/// per-biobank ingestion adapter. A factory that accepted <c>"96,592"</c> would have a signature
+/// only one vendor's text file could ever call.
+/// </remarks>
+internal static class Normalize
+{
+    /// <summary>Trim, and treat a blank string as absent. The base cleaning every other rule builds on.</summary>
+    public static string? Text(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    /// <summary>
+    /// <see cref="Text"/>, then collapse runs of internal whitespace to a single space. For free-text
+    /// labels copied out of sample sheets and vendor reports, where spacing is incidental.
+    /// </summary>
+    public static string? Collapse(string? value) =>
+        Text(value) is { } trimmed
+            ? string.Join(' ', trimmed.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            : null;
+
+    /// <summary>
+    /// <see cref="Text"/> + upper-case. For values that are conventionally upper-case and must
+    /// compare equal across sources: instrument ids, flowcell ids, barcodes, alleles, gene symbols.
+    /// </summary>
+    public static string? Upper(string? value) => Text(value)?.ToUpperInvariant();
+
+    /// <summary><see cref="Text"/> + lower-case. For classification labels and file formats.</summary>
+    public static string? Lower(string? value) => Text(value)?.ToLowerInvariant();
+
+    /// <summary>
+    /// Canonical form of a sequencing-run id. A run can be discovered more than once in one source
+    /// tree — the data report finds every failed-to-organise run also present in the organised tree,
+    /// and one run id living under two different subtype folders. De-duplication keys on this, so
+    /// <see cref="SequencingRunId"/> must be normalised identically wherever it is produced.
+    /// </summary>
+    public static string? RunId(string? value) => Upper(value);
+
+    /// <summary>
+    /// Clean a list of symbol-like codes (gene names): upper-case each, drop blanks, de-duplicate,
+    /// and keep the source order. Never null — an absent list is an empty one.
+    /// </summary>
+    public static IReadOnlyList<string> Symbols(IEnumerable<string>? values) =>
+        values is null
+            ? []
+            : [.. values.Select(Upper).OfType<string>().Distinct(StringComparer.Ordinal)];
+}

--- a/src/SequencingApi/SequencingApi.Domain/Enums.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Enums.cs
@@ -1,0 +1,73 @@
+namespace SequencingApi.Domain;
+
+/// <summary>
+/// The molecule a sample was sequenced as. A single run mixes both, and the same sample may be
+/// sequenced as DNA in one run and RNA in another — they feed different analyses (variant calling
+/// vs fusion/expression), so aggregations must never collapse them together.
+/// </summary>
+public enum SampleType
+{
+    Dna,
+    Rna,
+}
+
+/// <summary>
+/// What a <see cref="Samples.SequencingFile"/> is, independent of its format or producer. One
+/// generic file table keyed by role means a new artifact kind needs no new type.
+/// </summary>
+public enum FileRole
+{
+    /// <summary>Raw reads straight off the sequencer.</summary>
+    Fastq,
+
+    /// <summary>Reads aligned to a reference genome.</summary>
+    Bam,
+
+    /// <summary>Index accompanying a <see cref="Bam"/>.</summary>
+    BamIndex,
+
+    /// <summary>Called variants, unfiltered.</summary>
+    Vcf,
+
+    /// <summary>Called variants after the caller's quality filters.</summary>
+    VcfFiltered,
+
+    /// <summary>Tabular per-variant report (the same calls in the vendor's own format).</summary>
+    VariantReport,
+
+    /// <summary>Per-region coverage report backing the coverage QC metrics.</summary>
+    CoverageReport,
+
+    /// <summary>Human-readable summary for clinical review.</summary>
+    SummaryReport,
+
+    /// <summary>
+    /// Anything else the source carries. The escape hatch that keeps this a closed enum: an
+    /// unrecognised artifact is still representable, and its path still identifies it.
+    /// </summary>
+    Other,
+}
+
+/// <summary>What an <see cref="Samples.Analysis"/> set out to determine.</summary>
+public enum AnalysisType
+{
+    VariantCalling,
+    Expression,
+    Fusion,
+    CopyNumber,
+
+    /// <summary>An analysis whose purpose the source does not state.</summary>
+    Other,
+}
+
+/// <summary>
+/// A recorded overall quality verdict. The domain stores the verdict someone else reached; it does
+/// not compute one, because the thresholds behind it are configuration and must be able to change
+/// without a code change (the raw metrics are kept alongside precisely so they can be re-judged).
+/// </summary>
+public enum QualityVerdict
+{
+    Pass,
+    Warn,
+    Fail,
+}

--- a/src/SequencingApi/SequencingApi.Domain/Panels/PanelAggregate.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Panels/PanelAggregate.cs
@@ -1,0 +1,93 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Panels;
+
+/// <summary>
+/// A target panel — the gene set and target regions a library was enriched for, and therefore what
+/// a sequencing result is capable of showing at all. Its own aggregate root because hundreds of
+/// samples share one panel; embedding it in each of them would duplicate the same gene list
+/// thousands of times.
+/// </summary>
+/// <remarks>
+/// A panel is not recorded inside the run it was used for — at MMCI it comes from a separately
+/// maintained, versioned libraries table, matched to a sample after the fact. That matching is the
+/// ingestion adapter's job; this aggregate only holds the resolved panel.
+/// </remarks>
+public sealed class PanelAggregate : AggregateRoot<PanelId>
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. See SequencingApi.Domain InternalsVisibleTo.
+    internal PanelAggregate()
+    {
+    }
+
+    public required string Name { get; init; }
+
+    public string? Abbreviation { get; init; }
+
+    public string? Vendor { get; init; }
+
+    public string? Assay { get; init; }
+
+    /// <summary>The panel's code in the downstream data catalogue, when the source records one.</summary>
+    public string? CatalogueCode { get; init; }
+
+    /// <summary>Genes the panel covers. Empty when the source did not state them.</summary>
+    public IReadOnlyList<string> Genes { get; init; } = [];
+
+    /// <summary>
+    /// Reference to the target-region definition (a BED file) the panel enriches for. The same
+    /// reference appears in coverage QC, which is what ties achieved coverage back to the panel.
+    /// </summary>
+    public string? TargetRegionsRef { get; init; }
+
+    /// <summary>Start of the window in which this panel was in use; null when open-ended.</summary>
+    public DateOnly? AvailableFrom { get; init; }
+
+    /// <summary>End of the window in which this panel was in use; null when still current.</summary>
+    public DateOnly? AvailableTo { get; init; }
+
+    public static ErrorOr<PanelAggregate> Create(
+        string panelId,
+        string name,
+        string? abbreviation = null,
+        string? vendor = null,
+        string? assay = null,
+        string? catalogueCode = null,
+        IReadOnlyList<string>? genes = null,
+        string? targetRegionsRef = null,
+        DateOnly? availableFrom = null,
+        DateOnly? availableTo = null)
+    {
+        if (Normalize.Text(panelId) is not { } cleanPanelId)
+        {
+            return Error.Validation("Panel.PanelId", "panel_id must not be empty");
+        }
+
+        if (Normalize.Collapse(name) is not { } cleanName)
+        {
+            return Error.Validation("Panel.Name", "name must not be empty");
+        }
+
+        // An inverted window silently selects the wrong panel when a sample is matched by run date.
+        if (availableFrom is { } from && availableTo is { } to && from > to)
+        {
+            return Error.Validation("Panel.AvailableTo", $"availability range is inverted: {from} > {to}");
+        }
+
+        return new PanelAggregate
+        {
+            Id = new PanelId(cleanPanelId),
+            Name = cleanName,
+            Abbreviation = Normalize.Upper(abbreviation),
+            Vendor = Normalize.Collapse(vendor),
+            Assay = Normalize.Collapse(assay),
+            CatalogueCode = Normalize.Text(catalogueCode),
+            Genes = Normalize.Symbols(genes),
+            TargetRegionsRef = Normalize.Text(targetRegionsRef),
+            AvailableFrom = availableFrom,
+            AvailableTo = availableTo,
+        };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/QualityMetrics.cs
+++ b/src/SequencingApi/SequencingApi.Domain/QualityMetrics.cs
@@ -1,0 +1,181 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain;
+
+/// <summary>
+/// How well a piece of sequencing worked: how deeply the target was covered, how much of the data
+/// was usable, and a summary of what was called from it.
+/// </summary>
+/// <remarks>
+/// Attached to an <see cref="Samples.Analysis"/>, because that is where these numbers are actually
+/// produced — every one of them is computed by the pipeline while aligning reads and calling
+/// variants, not by the instrument. Run-level quality is a different and much smaller thing and
+/// sits directly on the run instead of forcing this type to be mostly null there.
+/// <para>
+/// A closed, typed set of metrics that are comparable across biobanks, rather than an open
+/// name/value bag. That is a deliberate trade: a site-specific metric cannot be attached without a
+/// schema change, but every metric here is queryable and validated, and anything omitted is still
+/// recoverable by re-reading the source file. Metrics named <c>...Percent</c> are on a 0-100 scale,
+/// never 0-1 — the sources quote them with a percent sign, and an unnamed unit is a bug waiting to
+/// happen.
+/// </para>
+/// </remarks>
+public sealed record QualityMetrics : ValueObject
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. A record's implicit parameterless constructor would otherwise be
+    // public and let callers bypass Create entirely.
+    internal QualityMetrics()
+    {
+    }
+
+    /// <summary>Mean read depth across the target regions.</summary>
+    public double? AverageCoverage { get; init; }
+
+    /// <summary>Share of the target region covered at least 100x, 0-100.</summary>
+    public double? PctTargetOver100x { get; init; }
+
+    public int? MedianReadDepth { get; init; }
+
+    public int? ObservedReadLength { get; init; }
+
+    public long? TotalReads { get; init; }
+
+    public long? AlignedReads { get; init; }
+
+    /// <summary>Share of reads landing inside the target regions rather than off-target, 0-100.</summary>
+    public double? OnTargetRatePercent { get; init; }
+
+    /// <summary>
+    /// How many variants were called. A summary only — the individual variant records are
+    /// deliberately not modelled, see <see cref="Samples.Analysis"/>.
+    /// </summary>
+    public int? TotalVariants { get; init; }
+
+    /// <summary>Transition/transversion ratio — a sanity check on the variant calling itself.</summary>
+    public double? TsTvRatio { get; init; }
+
+    public int? HomozygousVariants { get; init; }
+
+    public int? HeterozygousVariants { get; init; }
+
+    /// <summary>
+    /// The quality verdict the source recorded, if any. Never computed here: the thresholds behind
+    /// it are configuration, and the raw metrics above are kept so it can be re-judged.
+    /// </summary>
+    public QualityVerdict? Verdict { get; init; }
+
+    public static ErrorOr<QualityMetrics> Create(
+        double? averageCoverage = null,
+        double? pctTargetOver100x = null,
+        int? medianReadDepth = null,
+        int? observedReadLength = null,
+        long? totalReads = null,
+        long? alignedReads = null,
+        double? onTargetRatePercent = null,
+        int? totalVariants = null,
+        double? tsTvRatio = null,
+        int? homozygousVariants = null,
+        int? heterozygousVariants = null,
+        QualityVerdict? verdict = null)
+    {
+        if (pctTargetOver100x is { } targetPct && targetPct is < 0 or > 100)
+        {
+            return Error.Validation(
+                "QualityMetrics.PctTargetOver100x",
+                $"pct_target_over_100x must be 0-100, got {targetPct}");
+        }
+
+        if (onTargetRatePercent is { } onTarget && onTarget is < 0 or > 100)
+        {
+            return Error.Validation(
+                "QualityMetrics.OnTargetRatePercent",
+                $"on_target_rate_percent must be 0-100, got {onTarget}");
+        }
+
+        if (averageCoverage is < 0)
+        {
+            return Error.Validation(
+                "QualityMetrics.AverageCoverage",
+                $"average_coverage must not be negative, got {averageCoverage}");
+        }
+
+        if (medianReadDepth is < 0)
+        {
+            return Error.Validation(
+                "QualityMetrics.MedianReadDepth",
+                $"median_read_depth must not be negative, got {medianReadDepth}");
+        }
+
+        if (observedReadLength is < 0)
+        {
+            return Error.Validation(
+                "QualityMetrics.ObservedReadLength",
+                $"observed_read_length must not be negative, got {observedReadLength}");
+        }
+
+        if (totalReads is < 0)
+        {
+            return Error.Validation("QualityMetrics.TotalReads", $"total_reads must not be negative, got {totalReads}");
+        }
+
+        if (alignedReads is < 0)
+        {
+            return Error.Validation(
+                "QualityMetrics.AlignedReads",
+                $"aligned_reads must not be negative, got {alignedReads}");
+        }
+
+        if (totalVariants is < 0)
+        {
+            return Error.Validation(
+                "QualityMetrics.TotalVariants",
+                $"total_variants must not be negative, got {totalVariants}");
+        }
+
+        if (tsTvRatio is < 0)
+        {
+            return Error.Validation("QualityMetrics.TsTvRatio", $"ts_tv_ratio must not be negative, got {tsTvRatio}");
+        }
+
+        if (homozygousVariants is < 0)
+        {
+            return Error.Validation(
+                "QualityMetrics.HomozygousVariants",
+                $"homozygous_variants must not be negative, got {homozygousVariants}");
+        }
+
+        if (heterozygousVariants is < 0)
+        {
+            return Error.Validation(
+                "QualityMetrics.HeterozygousVariants",
+                $"heterozygous_variants must not be negative, got {heterozygousVariants}");
+        }
+
+        // Cheap cross-check that catches a mis-parsed number landing in the wrong field — the most
+        // likely failure mode when the source quotes these with decimal commas.
+        if (totalReads is { } total && alignedReads is { } aligned && aligned > total)
+        {
+            return Error.Validation(
+                "QualityMetrics.AlignedReads",
+                $"aligned_reads cannot exceed total_reads ({aligned} > {total})");
+        }
+
+        return new QualityMetrics
+        {
+            AverageCoverage = averageCoverage,
+            PctTargetOver100x = pctTargetOver100x,
+            MedianReadDepth = medianReadDepth,
+            ObservedReadLength = observedReadLength,
+            TotalReads = totalReads,
+            AlignedReads = alignedReads,
+            OnTargetRatePercent = onTargetRatePercent,
+            TotalVariants = totalVariants,
+            TsTvRatio = tsTvRatio,
+            HomozygousVariants = homozygousVariants,
+            HeterozygousVariants = heterozygousVariants,
+            Verdict = verdict,
+        };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/Runs/ReadDefinition.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Runs/ReadDefinition.cs
@@ -1,0 +1,43 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Runs;
+
+/// <summary>
+/// One read in a run's read structure: how many cycles it sequenced, and whether it read a sample
+/// barcode (an index read) rather than the fragment itself (a template read).
+/// </summary>
+/// <remarks>
+/// This exists so <see cref="SequencingRunAggregate.ExpectedFastqFilesPerSample"/> can be derived
+/// instead of assumed. "Every run is paired-end, so two FASTQ files per sample" is false in the
+/// source corpus — a large minority of runs are single-read, and the only reliable way to know is
+/// to count the non-index reads the instrument actually performed.
+/// </remarks>
+public sealed record ReadDefinition : ValueObject
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. A record's implicit parameterless constructor would otherwise be
+    // public and let callers bypass Create entirely.
+    // ponytail: `existing with { ... }` still dodges validation via the synthesised copy
+    // constructor; accept that rather than turning every value object into a class.
+    internal ReadDefinition()
+    {
+    }
+
+    public required int NumCycles { get; init; }
+
+    /// <summary>True when this read reads a sample barcode rather than the fragment.</summary>
+    public required bool IsIndexedRead { get; init; }
+
+    public static ErrorOr<ReadDefinition> Create(int numCycles, bool isIndexedRead)
+    {
+        // A zero-cycle read is not a read; left unguarded it silently zeroes the expected-FASTQ
+        // derivation that is this type's whole reason to exist.
+        if (numCycles < 1)
+        {
+            return Error.Validation("ReadDefinition.NumCycles", $"num_cycles must be positive, got {numCycles}");
+        }
+
+        return new ReadDefinition { NumCycles = numCycles, IsIndexedRead = isIndexedRead };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/Runs/SequencingRunAggregate.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Runs/SequencingRunAggregate.cs
@@ -1,0 +1,171 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Runs;
+
+/// <summary>
+/// One sequencing run — a single flowcell processed by a single instrument, carrying the metadata
+/// that applies to every sample multiplexed onto it.
+/// </summary>
+/// <remarks>
+/// Its own aggregate root because a run is shared by roughly a dozen samples: folding this metadata
+/// into each sample would duplicate it thousands of times over the corpus and give re-sequenced
+/// samples several disagreeing copies of the same run. Samples reference a run by
+/// <see cref="SequencingRunId"/> only.
+/// </remarks>
+public sealed class SequencingRunAggregate : AggregateRoot<SequencingRunId>
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. See SequencingApi.Domain InternalsVisibleTo.
+    internal SequencingRunAggregate()
+    {
+    }
+
+    public int? RunNumber { get; init; }
+
+    /// <summary>Instrument family, e.g. the sequencer model the run was performed on.</summary>
+    public string? InstrumentModel { get; init; }
+
+    /// <summary>
+    /// The individual machine. A biobank runs more than one instrument of the same model, so stats
+    /// and provenance key on this rather than on <see cref="InstrumentModel"/>.
+    /// </summary>
+    public string? InstrumentId { get; init; }
+
+    /// <summary>
+    /// Sequencing platform, e.g. the vendor ecosystem. Left an opaque string: a closed enum would
+    /// have a single member today and would have to change for every new vendor.
+    /// </summary>
+    public string? Platform { get; init; }
+
+    /// <summary>
+    /// How the source classifies this run within its own tree. Opaque on purpose — encoding one
+    /// biobank's folder vocabulary as a domain enum is exactly what keeps a model site-specific.
+    /// </summary>
+    public string? SourceClass { get; init; }
+
+    /// <summary>The date the run was performed. Date only — the sources record no time of day.</summary>
+    public DateOnly? RunDate { get; init; }
+
+    public string? FlowcellId { get; init; }
+
+    /// <summary>Lanes on the flowcell. Load-bearing: it is half of the expected-FASTQ derivation.</summary>
+    public int? LaneCount { get; init; }
+
+    /// <summary>The reads the instrument performed, in order. Empty when the source did not state them.</summary>
+    public IReadOnlyList<ReadDefinition> Reads { get; init; } = [];
+
+    public string? Assay { get; init; }
+
+    public string? Workflow { get; init; }
+
+    /// <summary>
+    /// The operator-entered experiment name. Cleaned of stray whitespace and nothing more — the
+    /// corpus holds a dozen-plus mutually inconsistent spellings, and deciding which panel a given
+    /// spelling means is source-specific matching that belongs in the ingestion adapter.
+    /// </summary>
+    public string? ExperimentName { get; init; }
+
+    public string? Chemistry { get; init; }
+
+    public string? ReagentKit { get; init; }
+
+    public DateTime? StartedAt { get; init; }
+
+    public DateTime? CompletedAt { get; init; }
+
+    /// <summary>
+    /// Share of bases the instrument called with high confidence across the whole run, 0-100. A
+    /// plain property rather than a quality-metrics object: this is the only quality number a run
+    /// produces, and everything else measured about sequencing is computed later by an analysis.
+    /// </summary>
+    public double? PercentageQ30 { get; init; }
+
+    /// <summary>
+    /// Reads that sequenced the fragment rather than a barcode — one for a single-read run, two for
+    /// a paired-end one.
+    /// </summary>
+    public int TemplateReadCount => Reads.Count(read => !read.IsIndexedRead);
+
+    /// <summary>
+    /// How many FASTQ files each sample in this run should have: one per template read per lane.
+    /// Null when the lane count is unknown.
+    /// </summary>
+    /// <remarks>
+    /// Derived, never assumed. "Two files per sample" holds only for paired-end single-lane runs;
+    /// single-read runs produce one and multi-lane runs several times more. A sample with fewer
+    /// files than this is missing data, which is only detectable if the expectation is computed
+    /// from what the instrument actually did.
+    /// </remarks>
+    public int? ExpectedFastqFilesPerSample => LaneCount is { } lanes ? TemplateReadCount * lanes : null;
+
+    public static ErrorOr<SequencingRunAggregate> Create(
+        string runId,
+        int? runNumber = null,
+        string? instrumentModel = null,
+        string? instrumentId = null,
+        string? platform = null,
+        string? sourceClass = null,
+        DateOnly? runDate = null,
+        string? flowcellId = null,
+        int? laneCount = null,
+        IReadOnlyList<ReadDefinition>? reads = null,
+        string? assay = null,
+        string? workflow = null,
+        string? experimentName = null,
+        string? chemistry = null,
+        string? reagentKit = null,
+        DateTime? startedAt = null,
+        DateTime? completedAt = null,
+        double? percentageQ30 = null)
+    {
+        // Normalize.RunId, not a local rule: RunSample normalizes its run id with the same helper,
+        // and if the two ever diverge, de-duplicating a run discovered twice silently stops working.
+        if (Normalize.RunId(runId) is not { } cleanRunId)
+        {
+            return Error.Validation("SequencingRun.RunId", "run_id must not be empty");
+        }
+
+        if (runNumber is < 0)
+        {
+            return Error.Validation("SequencingRun.RunNumber", $"run_number must not be negative, got {runNumber}");
+        }
+
+        if (laneCount is < 1)
+        {
+            return Error.Validation("SequencingRun.LaneCount", $"lane_count must be positive, got {laneCount}");
+        }
+
+        if (startedAt is { } started && completedAt is { } completed && completed < started)
+        {
+            return Error.Validation("SequencingRun.CompletedAt", "completed_at must not precede started_at");
+        }
+
+        if (percentageQ30 is { } q30 && q30 is < 0 or > 100)
+        {
+            return Error.Validation("SequencingRun.PercentageQ30", $"percentage_q30 must be 0-100, got {q30}");
+        }
+
+        return new SequencingRunAggregate
+        {
+            Id = new SequencingRunId(cleanRunId),
+            RunNumber = runNumber,
+            InstrumentModel = Normalize.Collapse(instrumentModel),
+            InstrumentId = Normalize.Upper(instrumentId),
+            Platform = Normalize.Collapse(platform),
+            SourceClass = Normalize.Lower(sourceClass),
+            RunDate = runDate,
+            FlowcellId = Normalize.Upper(flowcellId),
+            LaneCount = laneCount,
+            Reads = reads ?? [],
+            Assay = Normalize.Collapse(assay),
+            Workflow = Normalize.Collapse(workflow),
+            ExperimentName = Normalize.Collapse(experimentName),
+            Chemistry = Normalize.Collapse(chemistry),
+            ReagentKit = Normalize.Collapse(reagentKit),
+            StartedAt = startedAt,
+            CompletedAt = completedAt,
+            PercentageQ30 = percentageQ30,
+        };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/Samples/Analysis.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Samples/Analysis.cs
@@ -1,0 +1,85 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Samples;
+
+/// <summary>
+/// A bioinformatic analysis of one sample's reads from one run: what pipeline ran, against which
+/// reference, and what it produced — files and quality metrics.
+/// </summary>
+/// <remarks>
+/// Deliberately has no identifier of its own. The sources carry no analysis id, so minting one
+/// would mean inventing a rule (derive it from the path? from run plus sample?) purely to give a
+/// child a key it is never addressed by. If an analysis ever needs to be addressed directly, the
+/// persistence layer can assign a surrogate key then.
+/// <para>
+/// Pipeline-agnostic: any variant caller fits, because the vendor-specific parts stay in the
+/// ingestion adapter and only <see cref="PipelineName"/> / <see cref="PipelineVersion"/> record
+/// which one it was.
+/// </para>
+/// </remarks>
+public sealed record Analysis : ValueObject
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. A record's implicit parameterless constructor would otherwise be
+    // public and let callers bypass Create entirely.
+    internal Analysis()
+    {
+    }
+
+    public required AnalysisType AnalysisType { get; init; }
+
+    /// <summary>The pipeline that produced this. Required — an analysis with no pipeline is not one.</summary>
+    public required string PipelineName { get; init; }
+
+    public string? PipelineVersion { get; init; }
+
+    /// <summary>
+    /// Reference genome the reads were aligned against. Case preserved: reference-build names are
+    /// conventionally mixed-case and are compared against external catalogues verbatim.
+    /// </summary>
+    public string? ReferenceGenome { get; init; }
+
+    public DateTime? ProducedAt { get; init; }
+
+    // ponytail: individual variant records are deliberately not modelled — the data catalogue
+    // consumes none of them, and they would be by far the largest table in the service. Analyses
+    // reference their variant calls as files (FileRole.Vcf / VariantReport) and summarise them in
+    // Qc. Add a Variant entity the day something actually queries variants.
+
+    /// <summary>Files this analysis produced — alignments, variant calls, reports.</summary>
+    public IReadOnlyList<SequencingFile> Files { get; init; } = [];
+
+    /// <summary>
+    /// How well the sequencing behind this analysis worked, when the pipeline reported it. This is
+    /// the only place quality metrics hang: they are all computed here, while aligning reads and
+    /// calling variants.
+    /// </summary>
+    public QualityMetrics? Quality { get; init; }
+
+    public static ErrorOr<Analysis> Create(
+        AnalysisType analysisType,
+        string pipelineName,
+        string? pipelineVersion = null,
+        string? referenceGenome = null,
+        DateTime? producedAt = null,
+        IReadOnlyList<SequencingFile>? files = null,
+        QualityMetrics? quality = null)
+    {
+        if (Normalize.Collapse(pipelineName) is not { } cleanPipelineName)
+        {
+            return Error.Validation("Analysis.PipelineName", "pipeline_name must not be empty");
+        }
+
+        return new Analysis
+        {
+            AnalysisType = analysisType,
+            PipelineName = cleanPipelineName,
+            PipelineVersion = Normalize.Text(pipelineVersion),
+            ReferenceGenome = Normalize.Text(referenceGenome),
+            ProducedAt = producedAt,
+            Files = files ?? [],
+            Quality = quality,
+        };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/Samples/LibraryPreparation.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Samples/LibraryPreparation.cs
@@ -1,0 +1,90 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Samples;
+
+/// <summary>
+/// How a sample was turned into a sequencing library before it went on the instrument, and which
+/// target panel it was enriched for.
+/// </summary>
+/// <remarks>
+/// Every field is optional, including the panel. This information is not recorded in the run
+/// itself — it comes from a separately maintained libraries table whose columns differ between
+/// versions, matched to a sample after the fact by rules that regularly fail to resolve. A model
+/// that demanded any of it would reject data that legitimately exists.
+/// </remarks>
+public sealed record LibraryPreparation : ValueObject
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. A record's implicit parameterless constructor would otherwise be
+    // public and let callers bypass Create entirely.
+    internal LibraryPreparation()
+    {
+    }
+
+    /// <summary>The panel this library was enriched for, referenced by id. Null when unresolved.</summary>
+    public PanelId? PanelId { get; init; }
+
+    /// <summary>Amount of material the preparation started from.</summary>
+    public int? InputAmount { get; init; }
+
+    public string? LibraryPrepKit { get; init; }
+
+    /// <summary>Whether the preparation avoided a PCR amplification step.</summary>
+    public bool? PcrFree { get; init; }
+
+    public string? TargetEnrichmentKit { get; init; }
+
+    /// <summary>Whether unique molecular identifiers were used to distinguish duplicate reads.</summary>
+    public bool? UmiPresent { get; init; }
+
+    /// <summary>Fragment length the preparation aimed for.</summary>
+    public int? IntendedInsertSize { get; init; }
+
+    /// <summary>Read length the preparation was designed for, as opposed to what was observed.</summary>
+    public int? IntendedReadLength { get; init; }
+
+    public static ErrorOr<LibraryPreparation> Create(
+        PanelId? panelId = null,
+        int? inputAmount = null,
+        string? libraryPrepKit = null,
+        bool? pcrFree = null,
+        string? targetEnrichmentKit = null,
+        bool? umiPresent = null,
+        int? intendedInsertSize = null,
+        int? intendedReadLength = null)
+    {
+        if (inputAmount is < 0)
+        {
+            return Error.Validation(
+                "LibraryPreparation.InputAmount",
+                $"input_amount must not be negative, got {inputAmount}");
+        }
+
+        if (intendedInsertSize is < 1)
+        {
+            return Error.Validation(
+                "LibraryPreparation.IntendedInsertSize",
+                $"intended_insert_size must be positive, got {intendedInsertSize}");
+        }
+
+        if (intendedReadLength is < 1)
+        {
+            return Error.Validation(
+                "LibraryPreparation.IntendedReadLength",
+                $"intended_read_length must be positive, got {intendedReadLength}");
+        }
+
+        return new LibraryPreparation
+        {
+            PanelId = panelId,
+            InputAmount = inputAmount,
+            LibraryPrepKit = Normalize.Collapse(libraryPrepKit),
+            PcrFree = pcrFree,
+            TargetEnrichmentKit = Normalize.Collapse(targetEnrichmentKit),
+            UmiPresent = umiPresent,
+            IntendedInsertSize = intendedInsertSize,
+            IntendedReadLength = intendedReadLength,
+        };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/Samples/RunSample.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Samples/RunSample.cs
@@ -1,0 +1,113 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Samples;
+
+/// <summary>
+/// One sample as it was sequenced in one run: its place on that flowcell, the library it was
+/// prepared as, the reads that came off, and any analysis of them.
+/// </summary>
+/// <remarks>
+/// Identified by the run it belongs to. A sample is sequenced at most once per run, so within its
+/// owning <see cref="SampleAggregate"/> the run id is the only discriminator needed — the sample
+/// half of the natural key is the aggregate root itself and would be redundant here.
+/// <para>
+/// That identity is <em>local to the owning aggregate</em>: entity equality compares type and id
+/// only, so two run-samples belonging to different samples in the same run compare equal. That is
+/// correct inside an aggregate boundary and wrong outside one.
+/// </para>
+/// ponytail: local identity only; promote to a composite id if run-samples ever escape their
+/// aggregate and get compared across samples.
+/// </remarks>
+public sealed class RunSample : Entity<SequencingRunId>
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. See SequencingApi.Domain InternalsVisibleTo.
+    internal RunSample()
+    {
+    }
+
+    /// <summary>The run this sample was sequenced in — the same value as the entity id, named for what it is.</summary>
+    public SequencingRunId RunId => Id;
+
+    /// <summary>
+    /// This sample's position within the run, 1-based — the number the source stamps into its read
+    /// filenames. A position, not a barcode: the per-sample barcodes that multiplexed this flowcell
+    /// are deliberately not modelled, because de-multiplexing has already happened by the time the
+    /// data reaches us and nothing downstream asks which tag produced which file.
+    /// </summary>
+    public int? SampleIndex { get; init; }
+
+    /// <summary>
+    /// Which molecule was sequenced here. Null when the source does not distinguish. The same sample
+    /// can be sequenced as DNA in one run and RNA in another, so this belongs to the run-sample
+    /// rather than to the sample.
+    /// </summary>
+    public SampleType? SampleType { get; init; }
+
+    /// <summary>Lanes this sample's reads were spread across.</summary>
+    public int? LaneCount { get; init; }
+
+    /// <summary>How the library was prepared. Null when the source did not record it or it could not be resolved.</summary>
+    public LibraryPreparation? LibraryPreparation { get; init; }
+
+    /// <summary>
+    /// Files produced directly by sequencing this sample. Empty is a real and common state — a
+    /// sample folder can exist with no reads in it — so it is never rejected.
+    /// </summary>
+    public IReadOnlyList<SequencingFile> Files { get; init; } = [];
+
+    /// <summary>
+    /// Analyses of these reads. Empty for every source that stops at raw reads and analyses
+    /// elsewhere, which is a large share of the corpus.
+    /// </summary>
+    public IReadOnlyList<Analysis> Analyses { get; init; } = [];
+
+    // ponytail: no quality metrics hang here. Every per-sample quality number the sources produce is
+    // computed by the analysis pipeline and lives on Analysis; a Quality property here would be
+    // permanently null. Add one if a source ever measures quality without running an analysis.
+
+    /// <summary>Whether any reads actually arrived. A sample folder existing does not mean it has reads.</summary>
+    public bool HasFastq => Files.Any(file => file.Role == FileRole.Fastq);
+
+    /// <summary>Whether this sequencing was analysed, as opposed to being reads only.</summary>
+    public bool HasAnalysis => Analyses.Count > 0;
+
+    public static ErrorOr<RunSample> Create(
+        string runId,
+        int? sampleIndex = null,
+        SampleType? sampleType = null,
+        int? laneCount = null,
+        LibraryPreparation? libraryPreparation = null,
+        IReadOnlyList<SequencingFile>? files = null,
+        IReadOnlyList<Analysis>? analyses = null)
+    {
+        // Normalize.RunId, not a local rule: SequencingRunAggregate normalizes its id with the same
+        // helper, and if the two ever diverge, matching a run-sample to its run silently stops working.
+        if (Normalize.RunId(runId) is not { } cleanRunId)
+        {
+            return Error.Validation("RunSample.RunId", "run_id must not be empty");
+        }
+
+        if (sampleIndex is < 1)
+        {
+            return Error.Validation("RunSample.SampleIndex", $"sample_index must be positive, got {sampleIndex}");
+        }
+
+        if (laneCount is < 1)
+        {
+            return Error.Validation("RunSample.LaneCount", $"lane_count must be positive, got {laneCount}");
+        }
+
+        return new RunSample
+        {
+            Id = new SequencingRunId(cleanRunId),
+            SampleIndex = sampleIndex,
+            SampleType = sampleType,
+            LaneCount = laneCount,
+            LibraryPreparation = libraryPreparation,
+            Files = files ?? [],
+            Analyses = analyses ?? [],
+        };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/Samples/SampleAggregate.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Samples/SampleAggregate.cs
@@ -73,14 +73,15 @@ public sealed class SampleAggregate : AggregateRoot<SampleId>
         // under two different subtype folders. Without this guard the duplicate would be stored
         // twice and RunSample's run-scoped identity would stop being unique inside the aggregate.
         var seenRunIds = new HashSet<SequencingRunId>();
-        foreach (var runSample in resolvedRunSamples)
+        var duplicateRunSample = resolvedRunSamples
+            .Where(runSample => !seenRunIds.Add(runSample.RunId))
+            .FirstOrDefault();
+
+        if (duplicateRunSample is not null)
         {
-            if (!seenRunIds.Add(runSample.RunId))
-            {
-                return Error.Validation(
-                    "Sample.RunSamples",
-                    $"duplicate run_id in sample runs: {runSample.RunId}");
-            }
+            return Error.Validation(
+                "Sample.RunSamples",
+                $"duplicate run_id in sample runs: {duplicateRunSample.RunId}");
         }
 
         return new SampleAggregate

--- a/src/SequencingApi/SequencingApi.Domain/Samples/SampleAggregate.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Samples/SampleAggregate.cs
@@ -1,0 +1,94 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Samples;
+
+/// <summary>
+/// A sequenced sample — the aggregate root, and the unit everything about sequencing is asked for.
+/// Gathers every occasion the same sample was put on a sequencer, since a sample is routinely
+/// sequenced more than once.
+/// </summary>
+/// <remarks>
+/// Identified by an opaque <c>external_id</c> supplied by the source biobank, qualified by
+/// <see cref="IdScheme"/>. The domain never interprets the id: it is a join key, and the sequencing
+/// service deliberately holds no patient or clinical data — that is served by the patient API, and
+/// <see cref="SubjectRef"/> is only a pointer into it.
+/// <para>
+/// Runs and panels are referenced by identity, never held: both are shared by many samples and are
+/// their own aggregate roots.
+/// </para>
+/// </remarks>
+public sealed class SampleAggregate : AggregateRoot<SampleId>
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. See SequencingApi.Domain InternalsVisibleTo.
+    internal SampleAggregate()
+    {
+    }
+
+    /// <summary>
+    /// Which naming system <see cref="Entity{TId}.Id"/> belongs to. The single extension point that
+    /// keeps the id opaque: another biobank supplies ids in its own scheme, and nothing downstream
+    /// has to assume this one's shape. Kept beside the id rather than folded into it — a composite
+    /// identifier string is the very thing a typed id exists to prevent.
+    /// </summary>
+    public required string IdScheme { get; init; }
+
+    /// <summary>
+    /// Opaque pointer to the subject this sample was taken from, resolved by the patient API. Null
+    /// when the source carries no such link.
+    /// </summary>
+    public string? SubjectRef { get; init; }
+
+    /// <summary>
+    /// Every run this sample was sequenced in, at most one entry per run. Empty is legal: a sample
+    /// can be known without any usable sequencing having been found for it.
+    /// </summary>
+    public IReadOnlyList<RunSample> RunSamples { get; init; } = [];
+
+    /// <summary>Whether any of this sample's sequencing was analysed, as opposed to being reads only.</summary>
+    public bool HasAnalysis => RunSamples.Any(runSample => runSample.HasAnalysis);
+
+    public static ErrorOr<SampleAggregate> Create(
+        string externalId,
+        string idScheme,
+        string? subjectRef = null,
+        IReadOnlyList<RunSample>? runSamples = null)
+    {
+        // Trimmed but not case-folded: the id is opaque, and another scheme's ids may be case-significant.
+        if (Normalize.Text(externalId) is not { } cleanExternalId)
+        {
+            return Error.Validation("Sample.ExternalId", "external_id must not be empty");
+        }
+
+        if (Normalize.Lower(idScheme) is not { } cleanIdScheme)
+        {
+            return Error.Validation("Sample.IdScheme", "id_scheme must not be empty");
+        }
+
+        var resolvedRunSamples = runSamples ?? [];
+
+        // A run can be discovered more than once in one source tree — the same run id turns up both
+        // under a failed-processing folder and in the organised output, and one run id even lives
+        // under two different subtype folders. Without this guard the duplicate would be stored
+        // twice and RunSample's run-scoped identity would stop being unique inside the aggregate.
+        var seenRunIds = new HashSet<SequencingRunId>();
+        foreach (var runSample in resolvedRunSamples)
+        {
+            if (!seenRunIds.Add(runSample.RunId))
+            {
+                return Error.Validation(
+                    "Sample.RunSamples",
+                    $"duplicate run_id in sample runs: {runSample.RunId}");
+            }
+        }
+
+        return new SampleAggregate
+        {
+            Id = new SampleId(cleanExternalId),
+            IdScheme = cleanIdScheme,
+            SubjectRef = Normalize.Text(subjectRef),
+            RunSamples = resolvedRunSamples,
+        };
+    }
+}

--- a/src/SequencingApi/SequencingApi.Domain/Samples/SequencingFile.cs
+++ b/src/SequencingApi/SequencingApi.Domain/Samples/SequencingFile.cs
@@ -1,0 +1,85 @@
+using ErrorOr;
+using SequencingApi.Domain.Common;
+
+namespace SequencingApi.Domain.Samples;
+
+/// <summary>
+/// One file produced by sequencing or by an analysis of it, identified by what it is
+/// (<see cref="FileRole"/>) rather than by which column of a table it came from.
+/// </summary>
+/// <remarks>
+/// One generic file type instead of a property per format: reads, alignments, variant calls and
+/// reports all differ in role, not in structure, so a source that emits a new kind of artifact
+/// needs no new domain type.
+/// </remarks>
+public sealed record SequencingFile : ValueObject
+{
+    // Internal (not private) so the persistence mapper can reconstitute loaded rows; the public
+    // creation path stays Create. A record's implicit parameterless constructor would otherwise be
+    // public and let callers bypass Create entirely.
+    internal SequencingFile()
+    {
+    }
+
+    public required FileRole Role { get; init; }
+
+    /// <summary>Where the file lives, as the source addresses it.</summary>
+    public required string Path { get; init; }
+
+    /// <summary>File format, when the source distinguishes it from the role.</summary>
+    public string? Format { get; init; }
+
+    /// <summary>Flowcell lane this file's reads came from. Reads only.</summary>
+    public int? Lane { get; init; }
+
+    /// <summary>Which read of a fragment this file holds — 1 or 2 for paired-end. Reads only.</summary>
+    public int? Read { get; init; }
+
+    /// <summary>Size in bytes. Zero is a legitimate value: empty files occur in the sources.</summary>
+    public long? SizeBytes { get; init; }
+
+    public string? Checksum { get; init; }
+
+    public static ErrorOr<SequencingFile> Create(
+        FileRole role,
+        string path,
+        string? format = null,
+        int? lane = null,
+        int? read = null,
+        long? sizeBytes = null,
+        string? checksum = null)
+    {
+        if (Normalize.Text(path) is not { } cleanPath)
+        {
+            return Error.Validation("SequencingFile.Path", "path must not be empty");
+        }
+
+        if (lane is < 1)
+        {
+            return Error.Validation("SequencingFile.Lane", $"lane must be positive, got {lane}");
+        }
+
+        if (read is < 1)
+        {
+            return Error.Validation("SequencingFile.Read", $"read must be positive, got {read}");
+        }
+
+        // Note the boundary: negative is impossible, but zero is not rejected — a zero-byte file is
+        // a real state the sources produce, and the model has to be able to say so.
+        if (sizeBytes is < 0)
+        {
+            return Error.Validation("SequencingFile.SizeBytes", $"size_bytes must not be negative, got {sizeBytes}");
+        }
+
+        return new SequencingFile
+        {
+            Role = role,
+            Path = cleanPath,
+            Format = Normalize.Lower(format),
+            Lane = lane,
+            Read = read,
+            SizeBytes = sizeBytes,
+            Checksum = Normalize.Lower(checksum),
+        };
+    }
+}

--- a/tests/SequencingApi.UnitTests/DomainModelsTests.cs
+++ b/tests/SequencingApi.UnitTests/DomainModelsTests.cs
@@ -1,0 +1,376 @@
+using ErrorOr;
+using SequencingApi.Domain;
+using SequencingApi.Domain.Panels;
+using SequencingApi.Domain.Runs;
+using SequencingApi.Domain.Samples;
+using Xunit;
+
+namespace SequencingApi.UnitTests;
+
+public sealed class DomainModelsTests
+{
+    private static RunSample Run(string runId, params SequencingFile[] files) =>
+        RunSample.Create(runId, files: files).Value;
+
+    private static SequencingFile Fastq(string path, int lane = 1, int read = 1) =>
+        SequencingFile.Create(FileRole.Fastq, path, lane: lane, read: read).Value;
+
+    private static Analysis VariantCalling(params SequencingFile[] files) =>
+        Analysis.Create(AnalysisType.VariantCalling, "NextGENe", files: files).Value;
+
+    private static ReadDefinition Read(int cycles, bool index = false) =>
+        ReadDefinition.Create(cycles, index).Value;
+
+    // --- minimal construction --------------------------------------------------------
+
+    [Fact]
+    public void SampleMinimalConstructionStaysValid()
+    {
+        var sample = SampleAggregate.Create("mmci_predictive_1", "mmci_predictive").Value;
+
+        Assert.Equal("mmci_predictive_1", sample.Id.Value);
+        Assert.Equal("mmci_predictive", sample.IdScheme);
+        Assert.Null(sample.SubjectRef);
+        Assert.Empty(sample.RunSamples);
+        Assert.False(sample.HasAnalysis);
+    }
+
+    [Fact]
+    public void RunSampleMinimalConstructionStaysValid()
+    {
+        var runSample = RunSample.Create("240104_M02340_0399_LCBRW").Value;
+
+        Assert.Equal(runSample.Id, runSample.RunId);
+        Assert.Empty(runSample.Files);
+        Assert.Empty(runSample.Analyses);
+        Assert.False(runSample.HasFastq);
+        Assert.False(runSample.HasAnalysis);
+        Assert.Null(runSample.LibraryPreparation);
+    }
+
+    [Fact]
+    public void SequencingRunMinimalConstructionStaysValid()
+    {
+        var run = SequencingRunAggregate.Create("240104_M02340_0399_LCBRW").Value;
+
+        Assert.Empty(run.Reads);
+        Assert.Equal(0, run.TemplateReadCount);
+        Assert.Null(run.ExpectedFastqFilesPerSample);
+    }
+
+    [Fact]
+    public void PanelMinimalConstructionStaysValid()
+    {
+        var panel = PanelAggregate.Create("hypercap", "HyperCap").Value;
+
+        Assert.Equal("hypercap", panel.Id.Value);
+        Assert.Equal("HyperCap", panel.Name);
+        Assert.Empty(panel.Genes);
+    }
+
+    [Fact]
+    public void QualityMetricsAllowsEveryMetricAbsent() => Assert.Null(QualityMetrics.Create().Value.AverageCoverage);
+
+    // --- the reads-only case must be expressible -------------------------------------
+
+    [Fact]
+    public void FastqOnlySampleHasNoAnalysis()
+    {
+        var sample = SampleAggregate.Create(
+            "mmci_predictive_1",
+            "mmci_predictive",
+            runSamples: [Run("240102_NB552710_0064_AHG7LGBGXV", Fastq("R1.fastq.gz"))]).Value;
+
+        Assert.True(sample.RunSamples[0].HasFastq);
+        Assert.False(sample.HasAnalysis);
+    }
+
+    [Fact]
+    public void EmptyFastqFolderIsRepresentable()
+    {
+        var runSample = Run("240104_M02340_0399_LCBRW");
+
+        Assert.False(runSample.HasFastq);
+        Assert.Empty(runSample.Files);
+    }
+
+    [Fact]
+    public void AnalysedSampleReportsHasAnalysis()
+    {
+        var runSample = RunSample.Create(
+            "240104_M02340_0399_LCBRW",
+            files: [Fastq("R1.fastq.gz"), Fastq("R2.fastq.gz", read: 2)],
+            analyses: [VariantCalling(SequencingFile.Create(FileRole.Vcf, "sample.vcf").Value)]).Value;
+        var sample = SampleAggregate.Create("mmci_predictive_1", "mmci_predictive", runSamples: [runSample]).Value;
+
+        Assert.True(sample.HasAnalysis);
+        Assert.True(sample.RunSamples[0].HasFastq);
+        Assert.Equal(FileRole.Vcf, Assert.Single(sample.RunSamples[0].Analyses[0].Files).Role);
+    }
+
+    // --- expected FASTQ count is derived from the read structure, never assumed ------
+
+    [Fact]
+    public void PairedEndSingleLaneExpectsTwoFastqFiles()
+    {
+        var run = SequencingRunAggregate.Create(
+            "240104_M02340_0399_LCBRW",
+            laneCount: 1,
+            reads: [Read(151), Read(8, index: true), Read(151)]).Value;
+
+        Assert.Equal(2, run.TemplateReadCount);
+        Assert.Equal(2, run.ExpectedFastqFilesPerSample);
+    }
+
+    [Fact]
+    public void SingleReadRunExpectsOneFastqFile()
+    {
+        var run = SequencingRunAggregate.Create(
+            "240430_M02340_0430_MAMMA",
+            laneCount: 1,
+            reads: [Read(151), Read(8, index: true)]).Value;
+
+        Assert.Equal(1, run.ExpectedFastqFilesPerSample);
+    }
+
+    [Fact]
+    public void FourLanePairedEndRunExpectsEightFastqFiles()
+    {
+        var run = SequencingRunAggregate.Create(
+            "240102_NB552710_0064_AHG7LGBGXV",
+            laneCount: 4,
+            reads: [Read(151), Read(8, index: true), Read(8, index: true), Read(151)]).Value;
+
+        Assert.Equal(8, run.ExpectedFastqFilesPerSample);
+    }
+
+    [Fact]
+    public void ExpectedFastqCountIsUnknownWithoutLaneCount() =>
+        Assert.Null(SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", reads: [Read(151)])
+            .Value.ExpectedFastqFilesPerSample);
+
+    // --- sample invariants -----------------------------------------------------------
+
+    [Fact]
+    public void SampleRejectsEmptyExternalId() =>
+        AssertValidationError(SampleAggregate.Create("  ", "mmci_predictive"));
+
+    [Fact]
+    public void SampleRejectsEmptyIdScheme() =>
+        AssertValidationError(SampleAggregate.Create("mmci_predictive_1", " "));
+
+    [Fact]
+    public void SampleRejectsDuplicateRunIds() =>
+        AssertValidationError(SampleAggregate.Create(
+            "mmci_predictive_1",
+            "mmci_predictive",
+            runSamples: [Run("240430_M02340_0430_X"), Run("240430_M02340_0430_X")]));
+
+    [Fact]
+    public void SampleAcceptsTheSameSampleInDifferentRuns()
+    {
+        var sample = SampleAggregate.Create(
+            "mmci_predictive_1",
+            "mmci_predictive",
+            runSamples: [Run("240104_M02340_0399_LCBRW"), Run("240430_M02340_0430_X")]).Value;
+
+        Assert.Equal(2, sample.RunSamples.Count);
+    }
+
+    // --- run-sample invariants -------------------------------------------------------
+
+    [Fact]
+    public void RunSampleRejectsEmptyRunId() => AssertValidationError(RunSample.Create("   "));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void RunSampleRejectsNonPositiveSampleIndex(int sampleIndex) =>
+        AssertValidationError(RunSample.Create("240104_M02340_0399_LCBRW", sampleIndex: sampleIndex));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void RunSampleRejectsNonPositiveLaneCount(int laneCount) =>
+        AssertValidationError(RunSample.Create("240104_M02340_0399_LCBRW", laneCount: laneCount));
+
+    // --- file invariants -------------------------------------------------------------
+
+    [Fact]
+    public void SequencingFileRejectsEmptyPath() => AssertValidationError(SequencingFile.Create(FileRole.Bam, " "));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SequencingFileRejectsNonPositiveLane(int lane) =>
+        AssertValidationError(SequencingFile.Create(FileRole.Fastq, "R1.fastq.gz", lane: lane));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SequencingFileRejectsNonPositiveRead(int read) =>
+        AssertValidationError(SequencingFile.Create(FileRole.Fastq, "R1.fastq.gz", read: read));
+
+    [Fact]
+    public void SequencingFileRejectsNegativeSize() =>
+        AssertValidationError(SequencingFile.Create(FileRole.Fastq, "R1.fastq.gz", sizeBytes: -1));
+
+    [Fact]
+    public void SequencingFileAcceptsZeroByteFile() =>
+        Assert.Equal(0, SequencingFile.Create(FileRole.Other, "catalog_info.json", sizeBytes: 0).Value.SizeBytes);
+
+    // --- library preparation ---------------------------------------------------------
+
+    [Fact]
+    public void LibraryPreparationAllowsEverythingAbsent()
+    {
+        var preparation = LibraryPreparation.Create().Value;
+
+        Assert.Null(preparation.PanelId);
+        Assert.Null(preparation.LibraryPrepKit);
+    }
+
+    [Fact]
+    public void LibraryPreparationRejectsNegativeInputAmount() =>
+        AssertValidationError(LibraryPreparation.Create(inputAmount: -1));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void LibraryPreparationRejectsNonPositiveInsertSize(int insertSize) =>
+        AssertValidationError(LibraryPreparation.Create(intendedInsertSize: insertSize));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void LibraryPreparationRejectsNonPositiveReadLength(int readLength) =>
+        AssertValidationError(LibraryPreparation.Create(intendedReadLength: readLength));
+
+    // --- analysis --------------------------------------------------------------------
+
+    [Fact]
+    public void AnalysisRejectsEmptyPipelineName() =>
+        AssertValidationError(Analysis.Create(AnalysisType.VariantCalling, "  "));
+
+    [Fact]
+    public void AnalysisMinimalConstructionStaysValid()
+    {
+        var analysis = Analysis.Create(AnalysisType.VariantCalling, "NextGENe").Value;
+
+        Assert.Empty(analysis.Files);
+        Assert.Null(analysis.Quality);
+    }
+
+    // --- quality metrics -------------------------------------------------------------
+
+    [Fact]
+    public void QualityRejectsOutOfRangePercentages()
+    {
+        AssertValidationError(QualityMetrics.Create(pctTargetOver100x: 101));
+        AssertValidationError(QualityMetrics.Create(onTargetRatePercent: 100.5));
+    }
+
+    [Fact]
+    public void QualityRejectsNegativeCounts()
+    {
+        AssertValidationError(QualityMetrics.Create(averageCoverage: -1));
+        AssertValidationError(QualityMetrics.Create(medianReadDepth: -1));
+        AssertValidationError(QualityMetrics.Create(observedReadLength: -1));
+        AssertValidationError(QualityMetrics.Create(totalReads: -1));
+        AssertValidationError(QualityMetrics.Create(alignedReads: -1));
+        AssertValidationError(QualityMetrics.Create(totalVariants: -1));
+        AssertValidationError(QualityMetrics.Create(tsTvRatio: -1));
+        AssertValidationError(QualityMetrics.Create(homozygousVariants: -1));
+        AssertValidationError(QualityMetrics.Create(heterozygousVariants: -1));
+    }
+
+    [Fact]
+    public void QualityRejectsAlignedReadsExceedingTotalReads() =>
+        AssertValidationError(QualityMetrics.Create(totalReads: 100, alignedReads: 101));
+
+    [Fact]
+    public void QualityAcceptsAlignedReadsEqualToTotalReads() =>
+        Assert.Equal(100, QualityMetrics.Create(totalReads: 100, alignedReads: 100).Value.AlignedReads);
+
+    // --- run and read structure ------------------------------------------------------
+
+    [Fact]
+    public void SequencingRunRejectsEmptyRunId() => AssertValidationError(SequencingRunAggregate.Create(" "));
+
+    [Fact]
+    public void SequencingRunRejectsNegativeRunNumber() =>
+        AssertValidationError(SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", runNumber: -1));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SequencingRunRejectsNonPositiveLaneCount(int laneCount) =>
+        AssertValidationError(SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", laneCount: laneCount));
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(100.1)]
+    public void SequencingRunRejectsOutOfRangeQ30(double percentageQ30) =>
+        AssertValidationError(
+            SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", percentageQ30: percentageQ30));
+
+    [Fact]
+    public void SequencingRunKeepsQ30() =>
+        Assert.Equal(
+            94.5,
+            SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", percentageQ30: 94.5).Value.PercentageQ30);
+
+    [Fact]
+    public void SequencingRunRejectsCompletionBeforeStart() =>
+        AssertValidationError(SequencingRunAggregate.Create(
+            "240104_M02340_0399_LCBRW",
+            startedAt: new DateTime(2024, 1, 4, 11, 20, 0),
+            completedAt: new DateTime(2024, 1, 4, 11, 15, 0)));
+
+    [Fact]
+    public void SequencingRunAllowsCompletionAfterStart()
+    {
+        var run = SequencingRunAggregate.Create(
+            "240104_M02340_0399_LCBRW",
+            startedAt: new DateTime(2024, 1, 4, 11, 15, 0),
+            completedAt: new DateTime(2024, 1, 4, 19, 40, 0)).Value;
+
+        Assert.Equal(new DateTime(2024, 1, 4, 19, 40, 0), run.CompletedAt);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ReadDefinitionRejectsNonPositiveCycles(int cycles) =>
+        AssertValidationError(ReadDefinition.Create(cycles, isIndexedRead: false));
+
+    // --- panel invariants ------------------------------------------------------------
+
+    [Fact]
+    public void PanelRejectsEmptyPanelId() => AssertValidationError(PanelAggregate.Create(" ", "HyperCap"));
+
+    [Fact]
+    public void PanelRejectsEmptyName() => AssertValidationError(PanelAggregate.Create("hypercap", "  "));
+
+    [Fact]
+    public void PanelRejectsInvertedAvailabilityRange() =>
+        AssertValidationError(PanelAggregate.Create(
+            "hypercap",
+            "HyperCap",
+            availableFrom: new DateOnly(2024, 1, 1),
+            availableTo: new DateOnly(2023, 1, 1)));
+
+    [Fact]
+    public void PanelAllowsOpenEndedAvailability()
+    {
+        var panel = PanelAggregate.Create("hypercap", "HyperCap", availableFrom: new DateOnly(2024, 1, 1)).Value;
+
+        Assert.Null(panel.AvailableTo);
+    }
+
+    private static void AssertValidationError<T>(ErrorOr<T> result)
+    {
+        Assert.True(result.IsError);
+        Assert.Equal(ErrorType.Validation, result.FirstError.Type);
+    }
+}

--- a/tests/SequencingApi.UnitTests/NormalizationTests.cs
+++ b/tests/SequencingApi.UnitTests/NormalizationTests.cs
@@ -1,0 +1,157 @@
+using ErrorOr;
+using SequencingApi.Domain;
+using SequencingApi.Domain.Panels;
+using SequencingApi.Domain.Runs;
+using SequencingApi.Domain.Samples;
+using Xunit;
+
+namespace SequencingApi.UnitTests;
+
+/// <summary>
+/// Value cleaning is asserted through the factories rather than against the internal helper — the
+/// observable contract is what a created aggregate holds, not how it got there.
+/// </summary>
+public sealed class NormalizationTests
+{
+    // --- sample identity -------------------------------------------------------------
+
+    [Fact]
+    public void SampleTrimsExternalIdWithoutChangingCase() =>
+        Assert.Equal(
+            "mmci_predictive_AbC",
+            SampleAggregate.Create("  mmci_predictive_AbC  ", "mmci_predictive").Value.Id.Value);
+
+    [Fact]
+    public void SampleLowercasesIdScheme() =>
+        Assert.Equal(
+            "mmci_predictive",
+            SampleAggregate.Create("mmci_predictive_1", " MMCI_Predictive ").Value.IdScheme);
+
+    [Fact]
+    public void SampleTrimsBlankSubjectRefToNull() =>
+        Assert.Null(SampleAggregate.Create("mmci_predictive_1", "mmci_predictive", subjectRef: "   ").Value.SubjectRef);
+
+    // --- run id is the de-duplication key, so both sides must canonicalise identically
+
+    [Theory]
+    [InlineData("  240104_m02340_0399_lcbrw  ")]
+    [InlineData("240104_M02340_0399_LCBRW")]
+    public void RunIdIsTrimmedAndUpperCased(string rawRunId) =>
+        Assert.Equal("240104_M02340_0399_LCBRW", SequencingRunAggregate.Create(rawRunId).Value.Id.Value);
+
+    [Fact]
+    public void RunSampleAndRunNormalizeRunIdIdentically() =>
+        Assert.Equal(
+            SequencingRunAggregate.Create(" 240104_M02340_0399_LCBRW ").Value.Id,
+            RunSample.Create("240104_m02340_0399_lcbrw").Value.RunId);
+
+    [Fact]
+    public void SampleRejectsDuplicateRunIdsThatDifferOnlyByCase()
+    {
+        var result = SampleAggregate.Create(
+            "mmci_predictive_1",
+            "mmci_predictive",
+            runSamples:
+            [
+                RunSample.Create("240430_M02340_0430_X").Value,
+                RunSample.Create(" 240430_m02340_0430_x ").Value,
+            ]);
+
+        AssertValidationError(result);
+    }
+
+    // --- run text --------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("HyperCap-EP-240103", "HyperCap-EP-240103")]
+    [InlineData("  HyperCap_240103 ", "HyperCap_240103")]
+    [InlineData("TSO500  Run2024_9", "TSO500 Run2024_9")]
+    public void ExperimentNameOnlyLosesStrayWhitespace(string raw, string expected) =>
+        Assert.Equal(
+            expected,
+            SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", experimentName: raw).Value.ExperimentName);
+
+    [Fact]
+    public void InstrumentIdIsUpperCased() =>
+        Assert.Equal(
+            "NB552710",
+            SequencingRunAggregate.Create("230101_N0000000", instrumentId: " nb552710 ").Value.InstrumentId);
+
+    [Fact]
+    public void FlowcellIdIsUpperCased() =>
+        Assert.Equal(
+            "AHG7LGBGXV",
+            SequencingRunAggregate.Create("230101_N0000000", flowcellId: "ahg7lgbgxv").Value.FlowcellId);
+
+    [Fact]
+    public void SourceClassIsLowerCased() =>
+        Assert.Equal(
+            "miseq/complete-runs",
+            SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", sourceClass: " MiSEQ/Complete-Runs ")
+                .Value.SourceClass);
+
+    [Fact]
+    public void BlankRunTextBecomesNull() =>
+        Assert.Null(SequencingRunAggregate.Create("240104_M02340_0399_LCBRW", chemistry: "   ").Value.Chemistry);
+
+    // --- analysis --------------------------------------------------------------------
+
+    [Fact]
+    public void ReferenceGenomeKeepsItsCase() =>
+        Assert.Equal(
+            "GRCh37",
+            Analysis.Create(AnalysisType.VariantCalling, "NextGENe", referenceGenome: " GRCh37 ")
+                .Value.ReferenceGenome);
+
+    [Fact]
+    public void PipelineNameLosesStrayWhitespace() =>
+        Assert.Equal(
+            "NextGENe V2",
+            Analysis.Create(AnalysisType.VariantCalling, "  NextGENe   V2 ").Value.PipelineName);
+
+    // --- files -----------------------------------------------------------------------
+
+    [Fact]
+    public void SequencingFilePathIsTrimmed() =>
+        Assert.Equal("R1.fastq.gz", SequencingFile.Create(FileRole.Fastq, " R1.fastq.gz ").Value.Path);
+
+    [Fact]
+    public void SequencingFileFormatIsLowerCased() =>
+        Assert.Equal(
+            "fastq.gz",
+            SequencingFile.Create(FileRole.Fastq, "R1.fastq.gz", format: " FASTQ.GZ ").Value.Format);
+
+    // --- library preparation ---------------------------------------------------------
+
+    [Fact]
+    public void LibraryPrepKitLosesStrayWhitespace() =>
+        Assert.Equal(
+            "KAPA HyperPlus",
+            LibraryPreparation.Create(libraryPrepKit: " KAPA   HyperPlus ").Value.LibraryPrepKit);
+
+    // --- panel -----------------------------------------------------------------------
+
+    [Fact]
+    public void PanelGenesAreUpperCasedDedupedAndOrderPreserved() =>
+        Assert.Equal(
+            ["BRCA1", "BRCA2"],
+            PanelAggregate.Create("hypercap", "HyperCap", genes: ["brca1", " BRCA2 ", "  ", "BRCA1"]).Value.Genes);
+
+    [Fact]
+    public void PanelGenesDefaultToEmpty() =>
+        Assert.Empty(PanelAggregate.Create("hypercap", "HyperCap").Value.Genes);
+
+    [Fact]
+    public void PanelNameLosesStrayWhitespace() =>
+        Assert.Equal("Hyper Cap", PanelAggregate.Create("hypercap", " Hyper   Cap ").Value.Name);
+
+    [Fact]
+    public void PanelAbbreviationIsUpperCased() =>
+        Assert.Equal("MP", PanelAggregate.Create("mammaprint", "MammaPrint", abbreviation: " mp ").Value.Abbreviation);
+
+    private static void AssertValidationError<T>(ErrorOr<T> result)
+    {
+        Assert.True(result.IsError);
+        Assert.Equal(ErrorType.Validation, result.FirstError.Type);
+    }
+}


### PR DESCRIPTION
## Summary
Adds the `SequencingApi.Domain` model — three aggregate roots with invariants and value cleaning in their `Create(...)` factories, plus unit tests. No persistence, no ingestion, no endpoint.

## Motivation
Closes #54. The service had only `Common/` base types, blocking #55 (schema/persistence), #56 (ingestion) and #58 (the uploader's endpoint).

Generated from [`docs/sequencing-data-report.md`](docs/sequencing-data-report.md) §4 rather than from the issue's original "mirror the uploader's `SequencingDto` field set" wording — that report landed after the issue was filed and explicitly supersedes the old shape. Mapping down to `SequencingDto` stays with #58.

## Changes
```
SampleAggregate (SampleId = opaque external_id, + IdScheme)   PanelAggregate (PanelId)
  └── RunSample : Entity<SequencingRunId>                          ▲
        ├── LibraryPreparation?  ────────── PanelId ───────────────┘
        ├── SequencingFile[]  (by FileRole)
        └── Analysis[]                       SequencingRunAggregate (SequencingRunId)
              ├── SequencingFile[]             ├── ReadDefinition[]
              └── QualityMetrics?              └── PercentageQ30
```

- **Three roots**, referencing each other by identity only. A run is shared by ~12 samples and a panel by hundreds — embedding either would duplicate the same facts thousands of times and let re-sequenced samples hold copies that drift apart.
- **`RunSample` is identified by its run.** A sample is sequenced at most once per run, so inside the aggregate the run id is the only discriminator needed. `SampleAggregate.Create` rejects duplicate run ids, which is both the §6.3 guard and what keeps that local identity unique.
- **Invariants and value cleaning in the `Create` factories**, sharing the internal `Common/Normalize` helper. Cleaning is limited to already-typed values (trim, whitespace collapse, case folding, symbol lists); text encoding, decimal commas and panel alias matching are decoding and stay in the ingestion adapter per §4.3.
- **Derived, not assumed:** `ExpectedFastqFilesPerSample` = template reads × lanes. "Two files per sample" is false for single-read and multi-lane runs, and a sample short of its expected count is only detectable if the expectation comes from what the instrument actually did.
- **States the sources really produce stay valid:** empty FASTQ folders, zero-byte files, analyses that never ran, unresolved panels. Rejecting them would leave the model unable to express what happened.

### Deliberate omissions
Each is recorded in a `ponytail:` comment or a doc paragraph so it is not re-derived from §4 later:

| Omitted | Why |
|---|---|
| `Variant` records | Nothing in the catalogue path consumes them, and they would dominate the schema. Analyses reference their calls as files (`FileRole.Vcf`/`VariantReport`) and summarise them in `QualityMetrics`. |
| i7/i5 barcodes | De-multiplexing has already happened by the time the data reaches us; nothing downstream asks which tag produced which file. |
| `QualityMetrics` on `RunSample` / the run | Every metric in it is computed by the analysis pipeline. The run measures one number, so it carries a plain `PercentageQ30`; `RunSample` carries none. |
| `attributes` JSON bags, open-enum lookup tables | Closed enums and typed properties instead. `id_scheme` is the one extension point kept. |
| `AnalysisId`, surrogate `sample_id` | Persistence concerns; #55 can assign keys if EF needs them. |

Docs, both affected skills, and the `ponytail:` marker in `Common/Identifiers.cs` are updated.

## Verification
The four CI commands pass locally on this branch: `restore`, `format --verify-no-changes`, `build -c Release` (0 errors), `test -c Release` — **202 passing, 0 failing** (79 new in `SequencingApi.UnitTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
