### PR TITLE
Align the uploader with the biobank API contract

### DIFF
--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -35,7 +35,7 @@ inner layers are pure and trivial to test.
 
 | Symptom | Most likely layer | First thing to check |
 |---------|-------------------|----------------------|
-| Wrong/missing field on a domain object | `Application/Mapping/SourceMapper` (uploader) or `Xml/XmlValueReader` (biobank) | The hand-written mapping / DTO property name vs the source JSON key; `XmlValueReader` normalization. |
+| Wrong/missing field on a domain object | `Application/Mapping/` (uploader: `PatientMapper`, `SampleMapper`, …) or `Xml/XmlValueReader` (biobank) | The hand-written mapping / DTO property name vs the source JSON key; `XmlValueReader` normalization. A whole object arriving empty usually means the DTO's property names no longer match the source's - both sides serialize with `SnakeCaseLower`, so the names must agree; `Uploader.IntegrationTests`' `BiobankContractParityTests` names the offending key. |
 | Validation `ErrorOr` you didn't expect | `Domain` aggregate `Create(...)` | Which invariant fired - the `Error.Validation` code points at the field. |
 | Wrong CREATE/UPDATE/SKIP/DELETE decision | `Domain/Services/FingerprintSyncPlanner` + aggregate `ComputeFingerprint()` | What `Fingerprint.Of(...)` serializes, and the prior `SyncStatus`/`IsDeleted`. |
 | HTTP error, timeout, bad URL, auth | `Infrastructure/Http/*Gateway` | Request URL/params (from `UploaderOptions`) and the source/catalogue response. |

--- a/.claude/skills/docs-maintenance/SKILL.md
+++ b/.claude/skills/docs-maintenance/SKILL.md
@@ -40,7 +40,8 @@ Cross-check each item against the live code/config:
    `dotnet-tools.json`, and a doc must not describe a package the code doesn't reference. (FluentValidation
    is referenced now - it backs the application-level `ValidationBehavior` - so it is no longer a dead claim.)
 6. **Type & service names.** Domain services, aggregates, ports, and helpers named in docs/skills must exist
-   (`FingerprintSyncPlanner`, `Fingerprint.Of`/`ComputeFingerprint()`, `SourceMapper`, `XmlValueReader`,
+   (`FingerprintSyncPlanner`, `Fingerprint.Of`/`ComputeFingerprint()`, the uploader's per-source mappers
+   in `Mapping/` (there is no single `SourceMapper` any more), `XmlValueReader`,
    the `I*Gateway`/`I*Repository` ports). The biobank has no domain "cleaning service"; the uploader has no
    "FingerprintCalculator" - don't reintroduce names that aren't in the code.
 7. **No Python residue.** No `pytest`, `mypy`, `ruff`, `uv`, `dataclass`, `Protocol`, `apps/`, `alembic`,

--- a/.claude/skills/dotnet-dev/SKILL.md
+++ b/.claude/skills/dotnet-dev/SKILL.md
@@ -130,7 +130,7 @@ child collection gets rows with an explicit `Position` column (`run_read`), neve
 lives in a serialized string is order a query cannot restore. JSON columns are reserved for **scalar** lists
 (`patient.AccessionNumbers`, `panel.Genes`), stored via a `ValueConverter` + `ValueComparer` pair.
 
-**Mapping is hand-written.** DTO -> domain (uploader `SourceMapper`) and domain <-> EF entity
+**Mapping is hand-written.** DTO -> domain (uploader `Mapping/`, one mapper per source) and domain <-> EF entity
 (`PatientMapper`, `SyncStateMapper`) are plain static/instance classes with explicit `new T { ... }` field
 copies. There is no source generator, so a dropped or mis-sourced field is **not** a compile error: keep the
 public mapper signatures stable and cover every field with a round-trip / record-equality test (see the

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: Test conventions for the data-catalogue-upload .NET solution. Use when writing, running, or fixing tests in the test projects under tests/ (unit + integration per service) - unit-testing domain aggregates/factories, the FingerprintSyncPlanner, the SourceMapper and the sync handler with hand-written fakes; integration-testing EF Core repositories against in-memory SQLite (the SqliteDatabase helper) and the API hosts with WebApplicationFactory<Program>. xUnit, plain Assert, no mocking libraries.
+description: Test conventions for the data-catalogue-upload .NET solution. Use when writing, running, or fixing tests in the test projects under tests/ (unit + integration per service) - unit-testing domain aggregates/factories, the FingerprintSyncPlanner, the uploader's source mappers and the sync handler with hand-written fakes; integration-testing EF Core repositories against in-memory SQLite (the SqliteDatabase helper), source contracts against a recorded response, and the API hosts with WebApplicationFactory<Program>. xUnit, plain Assert, no mocking libraries.
 ---
 
 # Testing (data-catalogue-upload)
@@ -13,8 +13,8 @@ tests/
 ├── BiobankApi.IntegrationTests      ApiTests, RepositoryTests, MapperTests, XmlValueReaderTests, XmlExportParserTests
 ├── SequencingApi.UnitTests          DomainModelsTests, NormalizationTests (aggregates/factories), Mmci*Tests (pure source parsers)
 ├── SequencingApi.IntegrationTests   ApiTests, SequencingEndpointTests, RepositoryTests, MapperTests, StatsReaderTests, MmciSequencingDataSourceTests, IngestEndToEndTests
-├── Uploader.UnitTests               FingerprintSyncPlannerTests, FingerprintTests, SourceMapperTests, RunCatalogueSyncHandlerTests
-└── Uploader.IntegrationTests        SyncStateRepositoryTests
+├── Uploader.UnitTests               FingerprintSyncPlannerTests, FingerprintTests, UploaderMapperTests, UploaderMapperFieldParityTests, BiobankMappingTests, RunCatalogueSyncHandlerTests
+└── Uploader.IntegrationTests        SyncStateRepositoryTests, SyncStateMappersTests, BiobankFetchTests, BiobankContractParityTests
 ```
 
 Framework is **xUnit** (`[Fact]` / `[Theory]`) with plain `Assert.*`. **No FluentAssertions, no Moq /
@@ -157,6 +157,22 @@ var client = factory.CreateClient();
 ```
 
 JSON is **snake_case** (`JsonNamingPolicy.SnakeCaseLower`) - match that when deserializing responses in tests.
+
+## Integration tests: a source contract (uploader)
+
+A mapper unit test starts from a DTO that is already built, so it cannot see the failure that matters most
+here: a wire key no DTO property lands on, which turns a whole value object silently empty. `BiobankFetchTests`
+starts from the recorded `GET /patients` body in `tests/Uploader.IntegrationTests/TestData/` instead, drives it
+through the real `HttpSourceDataGateway` (internal, reachable via `InternalsVisibleTo`) with a stub
+`HttpMessageHandler`, and asserts the assembled aggregates. `BiobankContractParityTests` compares the served
+keys against the DTO property names (converted with `JsonNamingPolicy.SnakeCaseLower.ConvertName`) **in both
+directions**, so a rename fails as one missing key plus one orphaned property and an added field fails as a key
+with nowhere to go.
+
+Refresh the fixture from the real API when that test fails - that is the moment to decide what a new field maps
+to. Two things it deliberately does not do: reflect over the source service's response records (that would
+couple the two services' assemblies) and put `[JsonUnmappedMemberHandling(Disallow)]` on the DTOs (type-level,
+so production would throw the first time the source adds a field, when it should log and carry on).
 
 ## CI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Mirrors biobank_api (host + ingestion handler persisting through the repositorie
 
 ## uploader
 
-EF Core (Npgsql) + typed `HttpClient`s. Domain `PatientAggregate` + `Sample`/sequencing/WSI/radiology value objects and the `*SyncState` types; `FingerprintSyncPlanner` decides CREATE/UPDATE/SKIP/DELETE. CQRS: `RunCatalogueSyncCommand`. Host `Uploader.Host` applies migrations, runs the sync, prints a JSON summary, and exits `0` (no failures) or `1`. Config via env vars (`POSTGRES_*` + the five `*_API_URL`s); see `UploaderOptions`.
+EF Core (Npgsql) + typed `HttpClient`s. Domain `PatientAggregate` + `Sample`/sequencing/WSI/radiology value objects and the `*SyncState` types; `FingerprintSyncPlanner` decides CREATE/UPDATE/SKIP/DELETE. CQRS: `RunCatalogueSyncCommand`. **Each source API serves its own vocabulary and the uploader translates** - one mapper per source in `Application/Mapping/`, over DTOs in `Application/Dtos/` whose property names mirror the source's response records (both sides use `SnakeCaseLower`, so matching names are what makes the wire keys line up; `BiobankContractParityTests` guards that). The biobank's `p_tnm`, `morphology`, counts and the rest have no value-object slot yet and are dropped deliberately - each mapper names what it drops and why - and anything the catalogue's own vocabulary shapes (nullflavors, MOLGENIS lookup strings) waits for the catalogue contract. A patient is uploaded only when `PatientCatalogueData.IsUploadEligible`: consented **and** carrying at least one sample. Host `Uploader.Host` applies migrations, runs the sync, prints a JSON summary, and exits `0` (no failures) or `1`. Config via env vars (`POSTGRES_*` + the five `*_API_URL`s); see `UploaderOptions`.
 
 ## Commands
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ flowchart TD
 
     subgraph application [Application - CQRS]
         SyncService["RunCatalogueSyncCommandHandler"]
-        Mapper["SourceMapper (hand-written: DTO -> domain)"]
+        Mapper["Mapping/ (hand-written: source DTO -> domain)"]
         Ports["Abstractions (port interfaces)"]
     end
 
@@ -87,7 +87,7 @@ flowchart TD
 | Layer | Path | Responsibility |
 |-------|------|----------------|
 | Domain | `src/Uploader/Uploader.Domain/` | Record models + aggregates, the domain service `FingerprintSyncPlanner`, and the `Fingerprint` value object each aggregate uses for its `ComputeFingerprint()`. No I/O, no framework dependencies. |
-| Application | `src/Uploader/Uploader.Application/` | CQRS `RunCatalogueSyncCommand` + handler, `Dtos/` + the hand-written `SourceMapper` (`Mapping/`, DTO -> domain), and the port interfaces in `Abstractions/`. |
+| Application | `src/Uploader/Uploader.Application/` | CQRS `RunCatalogueSyncCommand` + handler, `Dtos/` + the hand-written mappers (`Mapping/`: one per source - `PatientMapper`, `SampleMapper`, `SequencingMapper`, `WsiMapper`, `ImagingStudyMapper` - plus `BiobankMapping` for the biobank's derived values), and the port interfaces in `Abstractions/`. |
 | Infrastructure | `src/Uploader/Uploader.Infrastructure/` | Adapters implementing the ports: typed `HttpClient` gateways (`Http/`) and EF Core + repositories (`Persistence/`). |
 
 The ports in `Uploader.Application/Abstractions` (`ISourceDataGateway`, `ICatalogueGateway`, `ISyncStateRepository`, `ISyncRunRepository`) are interfaces. Infrastructure provides concrete implementations, and `Uploader.Host` wires them together from environment variables. Planning is a domain service (`ISyncPlanner`).
@@ -120,13 +120,13 @@ flowchart TD
 ```
 
 1. **Fetch** all patients from the biobank API (`GET /patients`).
-2. **Aggregate** each patient: personal/clinical/material from the biobank payload, sequencing (by `predictive_number`), WSI (by `bioptic_number`), and radiology (by `accession_numbers`).
+2. **Aggregate** each patient: personal/clinical/material from the biobank payload, sequencing (by `predictive_number`), WSI (by `bioptic_number` - the biobank serves none, so this stays empty until #31), and radiology (by `accession_numbers`, patient-level and sample-level combined). The biobank serves its own vocabulary; translating it is the uploader's job, and the values it cannot place yet are carried raw until the catalogue contract fixes them.
 3. **Plan** per-entity operations in dependency order using SHA-256 fingerprints (each aggregate's `ComputeFingerprint()` over `Fingerprint.Of(...)`): CREATE when there is no prior state or the entity was soft-deleted, UPDATE when the fingerprint changed, SKIP when unchanged, DELETE when entities disappear from the source.
 4. **Execute** the plan against the catalogue API (upsert or delete per entity).
 5. **Patients missing** from the current run are deleted in the catalogue and soft-deleted in the DB subtree.
 6. **Persist** the run summary (scanned / changed / uploaded / deleted / skipped / failed) to `sync_run`.
 
-Upload eligibility: a patient is only uploaded if it has at least one sample (`PatientAggregate.IsUploadEligible()`).
+Upload eligibility: a patient is only uploaded if they consented and have at least one sample (`PatientCatalogueData.IsUploadEligible`). Consent is checked explicitly rather than being left to follow from the biobank refusing to attach samples to a non-consenting patient; it is permission, not content, so it stays out of the fingerprint.
 
 ## Sync state machine
 

--- a/src/Uploader/Uploader.Application/Dtos/PatientDto.cs
+++ b/src/Uploader/Uploader.Application/Dtos/PatientDto.cs
@@ -1,53 +1,100 @@
 namespace Uploader.Application.Dtos;
 
 /// <summary>
-/// Raw patient payload from the biobank API. Personal and clinical attributes are flattened onto
-/// the patient object; the mapper groups them into the domain value objects.
+/// Raw patient payload from the biobank API (<c>GET /patients</c>), in the biobank's own vocabulary.
+/// Property names mirror the biobank's response records one-for-one: both services serialize with
+/// <see cref="System.Text.Json.JsonNamingPolicy.SnakeCaseLower"/>, so identical names give identical
+/// wire keys and no <c>[JsonPropertyName]</c> is needed. Translating this into the catalogue's
+/// vocabulary is the uploader's job (see the mappers).
 /// </summary>
 public sealed record PatientDto
 {
     public string? PatientId { get; init; }
+    public string? Biobank { get; init; }
+    public bool? Consent { get; init; }
 
-    // Personal
-    public string? PersonalIdentifier { get; init; }
-    public int? YearOfBirth { get; init; }
-    public string? GenderAtBirth { get; init; }
-    public string? GenderIdentity { get; init; }
+    /// <summary><c>male</c> / <c>female</c>.</summary>
+    public string? Sex { get; init; }
 
-    // Clinical
-    public string? ClinicalIdentifier { get; init; }
-    public string? BelongsToPerson { get; init; }
-    public IReadOnlyList<string>? ClinicalDiagnosis { get; init; }
-    public int? AgeAtDiagnosis { get; init; }
-    public int? AgeOfOnset { get; init; }
+    public int? BirthYear { get; init; }
+
+    /// <summary>1-12. Not published; it only sharpens the age computation.</summary>
+    public int? BirthMonth { get; init; }
+
+    /// <summary>Patient-level radiology accession numbers.</summary>
+    public IReadOnlyList<string>? AccessionNumbers { get; init; }
 
     public IReadOnlyList<SampleDto>? Samples { get; init; }
-    public IReadOnlyList<string>? AccessionNumbers { get; init; }
+    public IReadOnlyList<SpecimenDto>? DiagnosticSpecimens { get; init; }
 }
 
-/// <summary>Raw sample payload; material attributes are flattened onto the sample object.</summary>
+/// <summary>
+/// Raw archived research sample. Flat across the three sample types with <see cref="Type"/> as the
+/// discriminator; the fields belonging to the other types come back null.
+/// </summary>
 public sealed record SampleDto
 {
     public string? SampleId { get; init; }
-    public string? PredictiveNumber { get; init; }
-    public string? BiopticNumber { get; init; }
 
-    // Material
-    public string? MaterialIdentifier { get; init; }
-    public string? CollectedFromPerson { get; init; }
-    public IReadOnlyList<string>? BelongsToDiagnosis { get; init; }
-    public string? SamplingTimestamp { get; init; }
-    public string? RegistrationTimestamp { get; init; }
-    public string? SamplingProtocol { get; init; }
-    public string? SamplingProtocolDeviation { get; init; }
-    public string? ReasonForSamplingProtocolDeviation { get; init; }
-    public string? BiospecimenType { get; init; }
-    public string? AnatomicalSource { get; init; }
-    public string? PathologicalState { get; init; }
-    public string? StorageConditions { get; init; }
-    public string? ExpirationDate { get; init; }
-    public double? PercentageTumorCells { get; init; }
-    public string? PhysicalLocation { get; init; }
-    public IReadOnlyList<string>? AnalysesPerformed { get; init; }
-    public string? DerivedFrom { get; init; }
+    /// <summary><c>tissue</c> / <c>serum</c> / <c>genome</c>.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>Biobank material code (<c>1</c>, <c>54</c>, <c>SD</c>, <c>PK</c>, …).</summary>
+    public string? MaterialType { get; init; }
+
+    /// <summary>English meaning of <see cref="MaterialType"/>, or null for an unknown code.</summary>
+    public string? MaterialTypeLabel { get; init; }
+
+    public int? EventNumber { get; init; }
+    public int? CollectionYear { get; init; }
+
+    /// <summary>Pathology case reference, <c>YYYY/{case}-{block}</c>. The <c>"-"</c> sentinel already arrives as null.</summary>
+    public string? Biopsy { get; init; }
+
+    /// <summary>Sequencing request key, <c>YYYY/{number}</c>. The <c>"-"</c> sentinel already arrives as null.</summary>
+    public string? PredictiveNumber { get; init; }
+
+    public int? SamplesNo { get; init; }
+    public int? AvailableSamplesNo { get; init; }
+    public IReadOnlyList<string>? AccessionNumbers { get; init; }
+
+    /// <summary>ICD-10, dot-less (<c>C504</c>). Tissue and serum only.</summary>
+    public string? Diagnosis { get; init; }
+
+    /// <summary>Pathological TNM staging, free text. Tissue only.</summary>
+    public string? PTnm { get; init; }
+
+    /// <summary>ICD-O-3 morphology code. Tissue only.</summary>
+    public string? Morphology { get; init; }
+
+    /// <summary>Tissue only: when the specimen was cut.</summary>
+    public DateTime? CutTime { get; init; }
+
+    /// <summary>Tissue only: when the specimen was frozen.</summary>
+    public DateTime? FreezeTime { get; init; }
+
+    /// <summary>Serum and genome only: when the sample was taken.</summary>
+    public DateTime? TakingDate { get; init; }
+
+    /// <summary><c>operational</c> / <c>unknown</c>.</summary>
+    public string? Retrieved { get; init; }
+}
+
+/// <summary>
+/// Raw diagnostic specimen: material consumed during diagnosis rather than archived for research.
+/// Only its diagnosis is carried into the patient record — see <c>PatientMapper</c>.
+/// </summary>
+public sealed record SpecimenDto
+{
+    public string? SpecimenId { get; init; }
+    public int? SpecimenNumber { get; init; }
+    public int? Year { get; init; }
+    public string? MaterialType { get; init; }
+    public string? MaterialTypeLabel { get; init; }
+
+    /// <summary>ICD-10, dot-less.</summary>
+    public string? Diagnosis { get; init; }
+
+    public DateTime? TakingDate { get; init; }
+    public string? Retrieved { get; init; }
 }

--- a/src/Uploader/Uploader.Application/Features/Sync/RunCatalogueSyncCommand.cs
+++ b/src/Uploader/Uploader.Application/Features/Sync/RunCatalogueSyncCommand.cs
@@ -214,7 +214,7 @@ internal sealed class RunCatalogueSyncCommandHandler
 
         foreach (var rawSample in rawPatient.Samples ?? [])
         {
-            var sampleResult = SampleMapper.ToSample(rawSample, patient.Id);
+            var sampleResult = SampleMapper.ToSample(rawSample, patient.Id, rawPatient.Biobank);
             if (sampleResult.IsError)
             {
                 return sampleResult.Errors;
@@ -254,7 +254,12 @@ internal sealed class RunCatalogueSyncCommandHandler
             }
         }
 
-        var accessionNumbers = rawPatient.AccessionNumbers ?? [];
+        // Samples carry accession numbers of their own, in the same namespace as the patient's.
+        var accessionNumbers = (rawPatient.AccessionNumbers ?? [])
+            .Concat((rawPatient.Samples ?? []).SelectMany(sample => sample.AccessionNumbers ?? []))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
         var studies = new List<ImagingStudyAggregate>();
         foreach (var studyDto in await _sourceGateway.FetchRadiologyAsync(accessionNumbers, cancellationToken))
         {

--- a/src/Uploader/Uploader.Application/Mapping/BiobankMapping.cs
+++ b/src/Uploader/Uploader.Application/Mapping/BiobankMapping.cs
@@ -1,0 +1,81 @@
+namespace Uploader.Application.Mapping;
+
+/// <summary>
+/// The computed pieces of the biobank -> domain mapping. Everything else is carried verbatim, so this
+/// is the whole of the mapping's logic: the derived clinical identifier, the ICD-10 dot rule and the
+/// age computation, all three ported from the previous production uploader. Catalogue vocabulary
+/// (MOLGENIS lookup strings, nullflavors) is deliberately absent — that belongs to the catalogue
+/// gateway, not here.
+/// </summary>
+internal static class BiobankMapping
+{
+    /// <summary>The biobank's discriminator for tissue samples.</summary>
+    public const string TissueType = "tissue";
+
+    /// <summary>The biobank's discriminator for genome samples.</summary>
+    public const string GenomeType = "genome";
+
+    public static bool IsTissue(string? sampleType) =>
+        string.Equals(sampleType, TissueType, StringComparison.OrdinalIgnoreCase);
+
+    public static bool IsGenome(string? sampleType) =>
+        string.Equals(sampleType, GenomeType, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Identifier of the patient's single clinical record, derived from the patient id. Once the
+    /// pseudonymized ids land (#80/S3) a <c>mmci_patient_&lt;uuid&gt;</c> becomes
+    /// <c>mmci_clinical_&lt;uuid&gt;</c>, which is what the previous uploader produced; a raw biobank
+    /// id just gets the prefix.
+    /// </summary>
+    public static string? ClinicalIdentifier(string? patientId)
+    {
+        if (string.IsNullOrWhiteSpace(patientId))
+        {
+            return null;
+        }
+
+        return patientId.Contains("patient", StringComparison.Ordinal)
+            ? patientId.Replace("patient", "clinical", StringComparison.Ordinal)
+            : $"clinical_{patientId}";
+    }
+
+    /// <summary>
+    /// The biobank exports ICD-10 dot-less (<c>C504</c>); the catalogue's code lists spell the
+    /// subcategory out (<c>C50.4</c>). Only a 4-character code has a subcategory to separate.
+    /// </summary>
+    public static string? Diagnosis(string? code)
+    {
+        var trimmed = code?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            return null;
+        }
+
+        return trimmed.Length == 4 ? $"{trimmed[..3]}.{trimmed[3]}" : trimmed;
+    }
+
+    /// <summary>
+    /// Whole years between the patient's birth and an event. The export carries no birth day, and
+    /// often no month either, so the birth date is taken as the first of the (defaulted) month —
+    /// the previous uploader's rule.
+    /// </summary>
+    public static int? AgeInYears(int? birthYear, int? birthMonth, DateTime? at)
+    {
+        if (birthYear is not { } year || at is not { } moment)
+        {
+            return null;
+        }
+
+        var month = birthMonth is >= 1 and <= 12 ? birthMonth.Value : 1;
+        var birth = new DateTime(year, month, 1);
+
+        var age = moment.Year - birth.Year;
+        if (moment < birth.AddYears(age))
+        {
+            age--;
+        }
+
+        // An event before the birth date is contradictory source data, not an age.
+        return age < 0 ? null : age;
+    }
+}

--- a/src/Uploader/Uploader.Application/Mapping/PatientMapper.cs
+++ b/src/Uploader/Uploader.Application/Mapping/PatientMapper.cs
@@ -4,26 +4,62 @@ using Uploader.Domain;
 
 namespace Uploader.Application.Mapping;
 
-/// <summary>Maps the raw biobank patient DTO onto the <see cref="PatientAggregate"/>.</summary>
+/// <summary>
+/// Maps the raw biobank patient DTO onto the <see cref="PatientAggregate"/>. Values are carried as
+/// the biobank serves them; only the clinical identifier, the ICD-10 dot rule and the age are derived
+/// (see <see cref="BiobankMapping"/>).
+/// <para>
+/// Deliberately dropped, because no value object holds them and nothing consumes them yet:
+/// <c>birth_month</c> (it only sharpens <see cref="Clinical.AgeAtDiagnosis"/>) and every diagnostic
+/// specimen field except its diagnosis — a specimen is material consumed during diagnosis, so
+/// publishing it as a catalogue sample would advertise material that no longer exists.
+/// </para>
+/// </summary>
 public static class PatientMapper
 {
     public static ErrorOr<PatientAggregate> ToPatient(PatientDto dto) =>
-        PatientAggregate.Create(dto.PatientId, ToPersonal(dto), ToClinical(dto));
+        PatientAggregate.Create(dto.PatientId, ToPersonal(dto), ToClinical(dto), dto.Consent == true);
 
     private static Personal ToPersonal(PatientDto dto) => new()
     {
-        PersonalIdentifier = dto.PersonalIdentifier,
-        YearOfBirth = dto.YearOfBirth,
-        GenderAtBirth = dto.GenderAtBirth,
-        GenderIdentity = dto.GenderIdentity,
+        PersonalIdentifier = dto.PatientId,
+        YearOfBirth = dto.BirthYear,
+        GenderAtBirth = dto.Sex,
+        GenderIdentity = null,
     };
 
     private static Clinical ToClinical(PatientDto dto) => new()
     {
-        ClinicalIdentifier = dto.ClinicalIdentifier,
-        BelongsToPerson = dto.BelongsToPerson,
-        ClinicalDiagnosis = dto.ClinicalDiagnosis,
-        AgeAtDiagnosis = dto.AgeAtDiagnosis,
-        AgeOfOnset = dto.AgeOfOnset,
+        ClinicalIdentifier = BiobankMapping.ClinicalIdentifier(dto.PatientId),
+        BelongsToPerson = dto.PatientId,
+        ClinicalDiagnosis = Diagnoses(dto),
+        AgeAtDiagnosis = BiobankMapping.AgeInYears(dto.BirthYear, dto.BirthMonth, EarliestEvent(dto)),
+        AgeOfOnset = null,
     };
+
+    /// <summary>
+    /// Every distinct ICD-10 code the patient's samples and diagnostic specimens carry. A genome
+    /// sample's diagnosis describes the blood draw rather than a diagnosed condition, so it is left
+    /// out. The order is fixed so the patient's fingerprint does not change with the source order.
+    /// </summary>
+    private static IReadOnlyList<string> Diagnoses(PatientDto dto)
+    {
+        var codes = (dto.Samples ?? [])
+            .Where(sample => !BiobankMapping.IsGenome(sample.Type))
+            .Select(sample => sample.Diagnosis)
+            .Concat((dto.DiagnosticSpecimens ?? []).Select(specimen => specimen.Diagnosis))
+            .Select(BiobankMapping.Diagnosis)
+            .OfType<string>();
+
+        return [.. codes.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// The earliest sample collection moment, which is as close as the export gets to a diagnosis
+    /// date. <c>Min</c> over nullables skips the nulls and answers null when there is nothing to take.
+    /// </summary>
+    private static DateTime? EarliestEvent(PatientDto dto) => (dto.Samples ?? []).Select(EventMoment).Min();
+
+    private static DateTime? EventMoment(SampleDto sample) =>
+        BiobankMapping.IsTissue(sample.Type) ? sample.FreezeTime : sample.TakingDate;
 }

--- a/src/Uploader/Uploader.Application/Mapping/SampleMapper.cs
+++ b/src/Uploader/Uploader.Application/Mapping/SampleMapper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using ErrorOr;
 using Uploader.Application.Dtos;
 using Uploader.Domain;
@@ -5,41 +6,48 @@ using Uploader.Domain.Common;
 
 namespace Uploader.Application.Mapping;
 
-/// <summary>Maps the raw biobank sample DTO onto the <see cref="SampleAggregate"/>.</summary>
+/// <summary>
+/// Maps the raw biobank sample DTO onto the <see cref="SampleAggregate"/>. The biobank's material
+/// code, location and timestamps are carried verbatim; turning them into the catalogue's vocabulary
+/// (biospecimen type, pathological state, storage conditions) waits for the catalogue contract.
+/// <para>
+/// Deliberately dropped, because no value object holds them and nothing consumes them yet:
+/// <c>p_tnm</c>, <c>morphology</c>, <c>retrieved</c>, <c>event_number</c>, <c>collection_year</c>,
+/// <c>samples_no</c>, <c>available_samples_no</c>, <c>material_type_label</c> (derivable from the
+/// code) and <c>biopsy</c>. <c>type</c> selects which timestamps apply rather than being stored.
+/// </para>
+/// </summary>
 public static class SampleMapper
 {
-    public static ErrorOr<SampleAggregate> ToSample(SampleDto dto, PatientId patientId) =>
+    public static ErrorOr<SampleAggregate> ToSample(SampleDto dto, PatientId patientId, string? biobank = null) =>
         SampleAggregate.Create(
             dto.SampleId,
             patientId,
             OptionalSequencingId(dto.PredictiveNumber),
-            OptionalWsiId(dto.BiopticNumber),
-            ToMaterial(dto));
+            // ponytail: no WSI link from this source yet. The key is `biopsy` ("2023/2872-1"): the
+            // previous uploader found the scans under <year>/<first 2>/<rest> as "2023_02872-01"
+            // (case zero-padded to 5, block to 2). Fill this in with #31, once the WSI service names
+            // its key.
+            wsiId: null,
+            ToMaterial(dto, patientId, biobank));
 
-    private static Material ToMaterial(SampleDto dto) => new()
+    private static Material ToMaterial(SampleDto dto, PatientId patientId, string? biobank) => new()
     {
-        MaterialIdentifier = dto.MaterialIdentifier,
-        CollectedFromPerson = dto.CollectedFromPerson,
-        BelongsToDiagnosis = dto.BelongsToDiagnosis,
-        SamplingTimestamp = dto.SamplingTimestamp,
-        RegistrationTimestamp = dto.RegistrationTimestamp,
-        SamplingProtocol = dto.SamplingProtocol,
-        SamplingProtocolDeviation = dto.SamplingProtocolDeviation,
-        ReasonForSamplingProtocolDeviation = dto.ReasonForSamplingProtocolDeviation,
-        BiospecimenType = dto.BiospecimenType,
-        AnatomicalSource = dto.AnatomicalSource,
-        PathologicalState = dto.PathologicalState,
-        StorageConditions = dto.StorageConditions,
-        ExpirationDate = dto.ExpirationDate,
-        PercentageTumorCells = dto.PercentageTumorCells,
-        PhysicalLocation = dto.PhysicalLocation,
-        AnalysesPerformed = dto.AnalysesPerformed,
-        DerivedFrom = dto.DerivedFrom,
+        MaterialIdentifier = dto.SampleId,
+        CollectedFromPerson = patientId.Value,
+        BelongsToDiagnosis = BelongsToDiagnosis(patientId),
+        SamplingTimestamp = Timestamp(BiobankMapping.IsTissue(dto.Type) ? dto.CutTime : dto.TakingDate),
+        RegistrationTimestamp = Timestamp(BiobankMapping.IsTissue(dto.Type) ? dto.FreezeTime : dto.TakingDate),
+        BiospecimenType = dto.MaterialType,
+        PhysicalLocation = biobank,
     };
+
+    /// <summary>The patient's single clinical record — the diagnosis this material belongs to.</summary>
+    private static IReadOnlyList<string> BelongsToDiagnosis(PatientId patientId) =>
+        BiobankMapping.ClinicalIdentifier(patientId.Value) is { } clinicalId ? [clinicalId] : [];
+
+    private static string? Timestamp(DateTime? value) => value?.ToString("s", CultureInfo.InvariantCulture);
 
     private static SequencingId? OptionalSequencingId(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : new SequencingId(value);
-
-    private static WsiId? OptionalWsiId(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? null : new WsiId(value);
 }

--- a/src/Uploader/Uploader.Domain/Patient/PatientAggregate.cs
+++ b/src/Uploader/Uploader.Domain/Patient/PatientAggregate.cs
@@ -17,16 +17,33 @@ public sealed class PatientAggregate : AggregateRoot<PatientId>
     public Personal? Personal { get; private init; }
     public Clinical? Clinical { get; private init; }
 
+    /// <summary>
+    /// Whether the patient consented to their data being shared. Permission to upload, not content —
+    /// so it stays out of <see cref="ComputeFingerprint"/> and is enforced by
+    /// <see cref="PatientCatalogueData.IsUploadEligible"/>.
+    /// </summary>
+    public bool HasConsent { get; private init; }
+
     /// <summary>Fingerprint over the patient's catalogue-relevant content.</summary>
     public Fingerprint ComputeFingerprint() => Fingerprint.Of(Personal, Clinical);
 
-    public static ErrorOr<PatientAggregate> Create(string? id, Personal? personal, Clinical? clinical)
+    public static ErrorOr<PatientAggregate> Create(
+        string? id,
+        Personal? personal,
+        Clinical? clinical,
+        bool hasConsent = false)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
             return Error.Validation("Patient.Id", "Patient id is required.");
         }
 
-        return new PatientAggregate { Id = new PatientId(id), Personal = personal, Clinical = clinical };
+        return new PatientAggregate
+        {
+            Id = new PatientId(id),
+            Personal = personal,
+            Clinical = clinical,
+            HasConsent = hasConsent,
+        };
     }
 }

--- a/src/Uploader/Uploader.Domain/Sync/PatientCatalogueData.cs
+++ b/src/Uploader/Uploader.Domain/Sync/PatientCatalogueData.cs
@@ -13,6 +13,10 @@ public sealed record PatientCatalogueData
     public IReadOnlyList<WsiAggregate> Wsis { get; init; } = [];
     public IReadOnlyList<ImagingStudyAggregate> ImagingStudies { get; init; } = [];
 
-    /// <summary>A patient is only uploaded to the catalogue when it has at least one sample.</summary>
-    public bool IsUploadEligible => Samples.Count > 0;
+    /// <summary>
+    /// A patient is only uploaded to the catalogue when they consented and have at least one sample.
+    /// The consent half is checked here rather than being left to follow from the biobank refusing to
+    /// attach samples to a non-consenting patient — an upload permission deserves its own test.
+    /// </summary>
+    public bool IsUploadEligible => Patient.HasConsent && Samples.Count > 0;
 }

--- a/tests/Uploader.IntegrationTests/BiobankContractParityTests.cs
+++ b/tests/Uploader.IntegrationTests/BiobankContractParityTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Uploader.Application.Dtos;
+using Xunit;
+
+namespace Uploader.IntegrationTests;
+
+/// <summary>
+/// Guards the uploader's side of the biobank contract: every key the API serves has a DTO property to
+/// land on, and every DTO property has a key. Both directions matter — a renamed field shows up as one
+/// missing key and one orphaned property, and a field the biobank adds shows up as a key with nowhere
+/// to go. Refresh <c>TestData/patients-response.json</c> from the biobank API when this fails; that is
+/// the moment to decide what the new field maps to.
+/// <para>
+/// The DTO carries every served field. Which of them the mappers deliberately leave behind
+/// (<c>p_tnm</c>, <c>morphology</c>, <c>retrieved</c>, the counts, …) is stated on the mappers and
+/// asserted in the uploader's mapper parity tests.
+/// </para>
+/// <para>
+/// The comparison goes through the fixture rather than reflecting over the biobank's own response
+/// records, which would couple this test project to <c>BiobankApi.Web</c>.
+/// </para>
+/// </summary>
+public sealed class BiobankContractParityTests
+{
+    private static readonly JsonDocument Response = JsonDocument.Parse(BiobankResponse.Json());
+
+    [Fact]
+    public void PatientKeysMatchThePatientDto() =>
+        AssertKeysMatch<PatientDto>(Patient());
+
+    [Fact]
+    public void SampleKeysMatchTheSampleDto() =>
+        AssertKeysMatch<SampleDto>(Patient().GetProperty("samples").EnumerateArray().First());
+
+    [Fact]
+    public void SpecimenKeysMatchTheSpecimenDto() =>
+        AssertKeysMatch<SpecimenDto>(Patient().GetProperty("diagnostic_specimens").EnumerateArray().First());
+
+    private static JsonElement Patient() => Response.RootElement[0];
+
+    private static void AssertKeysMatch<T>(JsonElement served)
+    {
+        var wireKeys = served.EnumerateObject().Select(property => property.Name).ToHashSet(StringComparer.Ordinal);
+        var dtoKeys = typeof(T)
+            .GetProperties()
+            .Select(property => JsonNamingPolicy.SnakeCaseLower.ConvertName(property.Name))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var unmapped = wireKeys.Except(dtoKeys).Order(StringComparer.Ordinal);
+        var orphaned = dtoKeys.Except(wireKeys).Order(StringComparer.Ordinal);
+
+        Assert.Equal(string.Empty, string.Join(", ", unmapped));  // served but no DTO property
+        Assert.Equal(string.Empty, string.Join(", ", orphaned));  // DTO property but never served
+    }
+}

--- a/tests/Uploader.IntegrationTests/BiobankFetchTests.cs
+++ b/tests/Uploader.IntegrationTests/BiobankFetchTests.cs
@@ -1,0 +1,92 @@
+using Uploader.Application.Dtos;
+using Uploader.Application.Mapping;
+using Uploader.Domain;
+using Uploader.Domain.Common;
+using Uploader.Infrastructure.Http;
+using Xunit;
+
+namespace Uploader.IntegrationTests;
+
+/// <summary>
+/// Wire to domain in one pass: a recorded <c>GET /patients</c> body goes through the real
+/// <see cref="HttpSourceDataGateway"/> and the mappers, and the assembled aggregates are inspected.
+/// This is what catches a serializer mismatch (a key like <c>p_tnm</c> that no DTO property lands on),
+/// which a mapper unit test cannot see because it starts from an already-built DTO.
+/// </summary>
+public sealed class BiobankFetchTests
+{
+    private static async Task<IReadOnlyList<PatientDto>> FetchAsync()
+    {
+        var gateway = new HttpSourceDataGateway(BiobankResponse.ClientFactory(BiobankResponse.Json()));
+        return await gateway.FetchPatientsAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task PatientArrivesWithDemographicsAndDiagnoses()
+    {
+        var dtos = await FetchAsync();
+
+        var dto = Assert.Single(dtos, p => p.PatientId == "P1");
+        var patient = PatientMapper.ToPatient(dto).Value;
+
+        Assert.Equal(new PatientId("P1"), patient.Id);
+        Assert.True(patient.HasConsent);
+        Assert.Equal("P1", patient.Personal!.PersonalIdentifier);
+        Assert.Equal("male", patient.Personal.GenderAtBirth);
+        Assert.Equal(1980, patient.Personal.YearOfBirth);
+
+        Assert.Equal("clinical_P1", patient.Clinical!.ClinicalIdentifier);
+        Assert.Equal("P1", patient.Clinical.BelongsToPerson);
+
+        // Tissue and serum both say C504, the specimen says C777, the genome sample says nothing.
+        Assert.Equal(["C50.4", "C77.7"], patient.Clinical.ClinicalDiagnosis);
+
+        // Earliest event is the tissue freeze on 2020-01-02; born 1980-04.
+        Assert.Equal(39, patient.Clinical.AgeAtDiagnosis);
+    }
+
+    [Fact]
+    public async Task SamplesArriveWithMaterialAndTheSequencingLink()
+    {
+        var dto = Assert.Single(await FetchAsync(), p => p.PatientId == "P1");
+        var patientId = new PatientId("P1");
+
+        var samples = (dto.Samples ?? [])
+            .Select(sample => SampleMapper.ToSample(sample, patientId, dto.Biobank).Value)
+            .ToDictionary(sample => sample.Id.Value);
+
+        Assert.Equal(3, samples.Count);
+
+        var tissue = samples["S-T"];
+        Assert.Equal("1", tissue.Material!.BiospecimenType);
+        Assert.Equal("BBM", tissue.Material.PhysicalLocation);
+        Assert.Equal("S-T", tissue.Material.MaterialIdentifier);
+        Assert.Equal("P1", tissue.Material.CollectedFromPerson);
+        Assert.Equal(["clinical_P1"], tissue.Material.BelongsToDiagnosis);
+        Assert.Equal("2020-01-02T03:04:05", tissue.Material.SamplingTimestamp);
+        Assert.Equal("2020-01-02T04:00:00", tissue.Material.RegistrationTimestamp);
+        Assert.Equal(new SequencingId("2020/1052"), tissue.SequencingId);
+
+        // The biobank serves a `biopsy` but no bioptic number: the WSI link waits for #31.
+        Assert.Null(tissue.WsiId);
+
+        var serum = samples["S-S"];
+        Assert.Equal("SD", serum.Material!.BiospecimenType);
+        Assert.Equal("2021-05-06T07:08:09", serum.Material.SamplingTimestamp);
+        Assert.Equal("2021-05-06T07:08:09", serum.Material.RegistrationTimestamp);
+        Assert.Null(serum.SequencingId);
+
+        Assert.Equal("gD", samples["S-G"].Material!.BiospecimenType);
+    }
+
+    [Fact]
+    public async Task PatientWithoutConsentIsNotUploadEligible()
+    {
+        var dto = Assert.Single(await FetchAsync(), p => p.PatientId == "P2");
+
+        var patient = PatientMapper.ToPatient(dto).Value;
+
+        Assert.False(patient.HasConsent);
+        Assert.False(new PatientCatalogueData { Patient = patient }.IsUploadEligible);
+    }
+}

--- a/tests/Uploader.IntegrationTests/BiobankResponse.cs
+++ b/tests/Uploader.IntegrationTests/BiobankResponse.cs
@@ -30,6 +30,9 @@ internal static class BiobankResponse
 
         public StubHandler(string json) => _json = json;
 
+        // The response is owned by whoever sent the request, as with any handler: HttpClient hands it
+        // to the caller, and HttpSourceDataGateway disposes it. Disposing it here would close the
+        // content before it could be read.
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken) =>

--- a/tests/Uploader.IntegrationTests/BiobankResponse.cs
+++ b/tests/Uploader.IntegrationTests/BiobankResponse.cs
@@ -10,7 +10,7 @@ namespace Uploader.IntegrationTests;
 internal static class BiobankResponse
 {
     public static string Json() =>
-        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "TestData", "patients-response.json"));
+        File.ReadAllText(Path.Join(AppContext.BaseDirectory, "TestData", "patients-response.json"));
 
     public static IHttpClientFactory ClientFactory(string json) => new StubHttpClientFactory(json);
 

--- a/tests/Uploader.IntegrationTests/BiobankResponse.cs
+++ b/tests/Uploader.IntegrationTests/BiobankResponse.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using System.Text;
+
+namespace Uploader.IntegrationTests;
+
+/// <summary>
+/// The recorded <c>GET /patients</c> payload plus the HTTP plumbing to serve it, so tests can drive
+/// the real <c>HttpSourceDataGateway</c> without a biobank service.
+/// </summary>
+internal static class BiobankResponse
+{
+    public static string Json() =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "TestData", "patients-response.json"));
+
+    public static IHttpClientFactory ClientFactory(string json) => new StubHttpClientFactory(json);
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        private readonly string _json;
+
+        public StubHttpClientFactory(string json) => _json = json;
+
+        public HttpClient CreateClient(string name) =>
+            new(new StubHandler(_json)) { BaseAddress = new Uri("http://biobank.test") };
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly string _json;
+
+        public StubHandler(string json) => _json = json;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_json, Encoding.UTF8, "application/json"),
+            });
+    }
+}

--- a/tests/Uploader.IntegrationTests/TestData/patients-response.json
+++ b/tests/Uploader.IntegrationTests/TestData/patients-response.json
@@ -1,0 +1,96 @@
+[
+  {
+    "patient_id": "P1",
+    "biobank": "BBM",
+    "consent": true,
+    "sex": "male",
+    "birth_year": 1980,
+    "birth_month": 4,
+    "accession_numbers": ["ACC1", "ACC2"],
+    "samples": [
+      {
+        "sample_id": "S-T",
+        "type": "tissue",
+        "material_type": "1",
+        "material_type_label": "Malignant tumour",
+        "event_number": 1,
+        "collection_year": 2020,
+        "biopsy": "2020/2872-1",
+        "predictive_number": "2020/1052",
+        "samples_no": 5,
+        "available_samples_no": 3,
+        "accession_numbers": ["ACC3"],
+        "diagnosis": "C504",
+        "p_tnm": "pT1",
+        "morphology": "8500/3",
+        "cut_time": "2020-01-02T03:04:05",
+        "freeze_time": "2020-01-02T04:00:00",
+        "taking_date": null,
+        "retrieved": "operational"
+      },
+      {
+        "sample_id": "S-S",
+        "type": "serum",
+        "material_type": "SD",
+        "material_type_label": "Serum, nitrogen-stored",
+        "event_number": null,
+        "collection_year": null,
+        "biopsy": null,
+        "predictive_number": null,
+        "samples_no": null,
+        "available_samples_no": null,
+        "accession_numbers": [],
+        "diagnosis": "C504",
+        "p_tnm": null,
+        "morphology": null,
+        "cut_time": null,
+        "freeze_time": null,
+        "taking_date": "2021-05-06T07:08:09",
+        "retrieved": "operational"
+      },
+      {
+        "sample_id": "S-G",
+        "type": "genome",
+        "material_type": "gD",
+        "material_type_label": "Extracted genomic DNA",
+        "event_number": null,
+        "collection_year": null,
+        "biopsy": null,
+        "predictive_number": null,
+        "samples_no": null,
+        "available_samples_no": null,
+        "accession_numbers": [],
+        "diagnosis": null,
+        "p_tnm": null,
+        "morphology": null,
+        "cut_time": null,
+        "freeze_time": null,
+        "taking_date": "2022-06-07T08:09:10",
+        "retrieved": "unknown"
+      }
+    ],
+    "diagnostic_specimens": [
+      {
+        "specimen_id": "D-1",
+        "specimen_number": 2,
+        "year": 2019,
+        "material_type": "S",
+        "material_type_label": "Serum / surgical specimen",
+        "diagnosis": "C777",
+        "taking_date": "2019-03-04T05:06:07",
+        "retrieved": "unknown"
+      }
+    ]
+  },
+  {
+    "patient_id": "P2",
+    "biobank": "BBM",
+    "consent": false,
+    "sex": "female",
+    "birth_year": 1975,
+    "birth_month": null,
+    "accession_numbers": [],
+    "samples": [],
+    "diagnostic_specimens": []
+  }
+]

--- a/tests/Uploader.IntegrationTests/Uploader.IntegrationTests.csproj
+++ b/tests/Uploader.IntegrationTests/Uploader.IntegrationTests.csproj
@@ -11,6 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- A recorded GET /patients payload, the contract the biobank API actually serves. -->
+    <Content Include="TestData\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Uploader.UnitTests/BiobankMappingTests.cs
+++ b/tests/Uploader.UnitTests/BiobankMappingTests.cs
@@ -1,0 +1,60 @@
+using Uploader.Application.Mapping;
+using Xunit;
+
+namespace Uploader.UnitTests;
+
+/// <summary>
+/// The three derived values in the biobank -> domain mapping. Everything else is carried verbatim,
+/// so this covers all of the mapping's logic.
+/// </summary>
+public sealed class BiobankMappingTests
+{
+    [Theory]
+    [InlineData("C504", "C50.4")]      // four characters: the last one is the subcategory
+    [InlineData("C50", "C50")]         // three: nothing to separate
+    [InlineData(" C774 ", "C77.4")]    // trimmed first
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void DiagnosisAppliesTheIcd10DotRule(string? code, string? expected) =>
+        Assert.Equal(expected, BiobankMapping.Diagnosis(code));
+
+    [Theory]
+    [InlineData("247", "clinical_247")]
+    [InlineData("mmci_patient_abc", "mmci_clinical_abc")]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void ClinicalIdentifierIsDerivedFromThePatientId(string? patientId, string? expected) =>
+        Assert.Equal(expected, BiobankMapping.ClinicalIdentifier(patientId));
+
+    [Fact]
+    public void AgeUsesTheBirthMonthWhenTheExportCarriesOne()
+    {
+        var event2020 = new DateTime(2020, 1, 2);
+
+        // Born June 1980: the 40th birthday is still months away in January 2020.
+        Assert.Equal(39, BiobankMapping.AgeInYears(1980, 6, event2020));
+
+        // No month recorded: January is assumed, so the birthday has already passed.
+        Assert.Equal(40, BiobankMapping.AgeInYears(1980, null, event2020));
+    }
+
+    [Fact]
+    public void AgeIsNullWithoutABirthYear() =>
+        Assert.Null(BiobankMapping.AgeInYears(null, 6, new DateTime(2020, 1, 2)));
+
+    [Fact]
+    public void AgeIsNullWithoutAnEventDate() =>
+        Assert.Null(BiobankMapping.AgeInYears(1980, 6, null));
+
+    [Fact]
+    public void AgeIsNullWhenTheEventPrecedesTheBirth() =>
+        Assert.Null(BiobankMapping.AgeInYears(1980, 1, new DateTime(1975, 1, 1)));
+
+    [Theory]
+    [InlineData("tissue", true)]
+    [InlineData("TISSUE", true)]
+    [InlineData("serum", false)]
+    [InlineData(null, false)]
+    public void TissueIsRecognisedCaseInsensitively(string? type, bool expected) =>
+        Assert.Equal(expected, BiobankMapping.IsTissue(type));
+}

--- a/tests/Uploader.UnitTests/FingerprintSyncPlannerTests.cs
+++ b/tests/Uploader.UnitTests/FingerprintSyncPlannerTests.cs
@@ -10,8 +10,12 @@ public sealed class FingerprintSyncPlannerTests
 {
     private readonly FingerprintSyncPlanner _planner = new();
 
-    private static PatientAggregate Patient(string id, Personal? personal = null, Clinical? clinical = null) =>
-        PatientAggregate.Create(id, personal, clinical).Value;
+    private static PatientAggregate Patient(
+        string id,
+        Personal? personal = null,
+        Clinical? clinical = null,
+        bool hasConsent = true) =>
+        PatientAggregate.Create(id, personal, clinical, hasConsent).Value;
 
     private static SampleAggregate Sample(string id, string patientId, string? sequencing = null, string? wsi = null) =>
         SampleAggregate.Create(
@@ -43,6 +47,20 @@ public sealed class FingerprintSyncPlannerTests
 
         var ops = _planner.Plan(data, PatientSyncStates.Empty());
 
+        var patientOp = Assert.IsType<PatientOperation>(Assert.Single(ops));
+        Assert.Equal(SyncOp.Skip, patientOp.Op);
+    }
+
+    [Fact]
+    public void PatientWithoutConsentIsSkippedEvenWithSamples()
+    {
+        var data = Data(
+            Patient("P1", new Personal { PersonalIdentifier = "P1" }, hasConsent: false),
+            Sample("S1", "P1"));
+
+        var ops = _planner.Plan(data, PatientSyncStates.Empty());
+
+        // The sample is not planned at all, and the patient itself is never uploaded.
         var patientOp = Assert.IsType<PatientOperation>(Assert.Single(ops));
         Assert.Equal(SyncOp.Skip, patientOp.Op);
     }

--- a/tests/Uploader.UnitTests/RunCatalogueSyncHandlerTests.cs
+++ b/tests/Uploader.UnitTests/RunCatalogueSyncHandlerTests.cs
@@ -24,8 +24,13 @@ public sealed class RunCatalogueSyncHandlerTests
             TimeProvider.System,
             NullLogger<RunCatalogueSyncCommandHandler>.Instance);
 
-    private static PatientDto PatientWithSample(string patientId, string sampleId) =>
-        new() { PatientId = patientId, Samples = [new SampleDto { SampleId = sampleId }] };
+    private static PatientDto PatientWithSample(string patientId, string sampleId, bool consent = true) =>
+        new()
+        {
+            PatientId = patientId,
+            Consent = consent,
+            Samples = [new SampleDto { SampleId = sampleId }],
+        };
 
     [Fact]
     public async Task UploadsNewPatientAndSample()
@@ -68,11 +73,38 @@ public sealed class RunCatalogueSyncHandlerTests
         Assert.Equal("sample failed", state.Samples["S1"].LastError);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(null)]
+    public async Task PatientWithoutConsentIsNeverUploaded(bool? consent)
+    {
+        // Sample and all: without a recorded "yes" nothing about this patient reaches the catalogue.
+        var patient = new PatientDto
+        {
+            PatientId = "P1",
+            Consent = consent,
+            Samples = [new SampleDto { SampleId = "S1" }],
+        };
+        var catalogue = new FakeCatalogueGateway();
+
+        var result = await CreateHandler(
+                new FakeSourceDataGateway([patient]),
+                catalogue,
+                new InMemorySyncStateRepository(),
+                new FakeSyncRunRepository())
+            .Handle(new RunCatalogueSyncCommand(), CancellationToken.None);
+
+        Assert.Empty(catalogue.Upserts);
+        Assert.Equal(1, result.Value.Scanned);
+        Assert.Equal(0, result.Value.Uploaded);
+        Assert.Equal(0, result.Value.Failed);
+    }
+
     [Fact]
     public async Task SkipsMalformedPatientWithoutCrashing()
     {
         // A blank patient id can't form a PatientId; the patient is failed, not fatal.
-        var source = new FakeSourceDataGateway([new PatientDto { PatientId = "", Samples = [new SampleDto { SampleId = "S1" }] }]);
+        var source = new FakeSourceDataGateway([new PatientDto { PatientId = "", Consent = true, Samples = [new SampleDto { SampleId = "S1" }] }]);
         var catalogue = new FakeCatalogueGateway();
 
         var result = await CreateHandler(source, catalogue, new InMemorySyncStateRepository(), new FakeSyncRunRepository())

--- a/tests/Uploader.UnitTests/UploaderMapperFieldParityTests.cs
+++ b/tests/Uploader.UnitTests/UploaderMapperFieldParityTests.cs
@@ -16,82 +16,104 @@ namespace Uploader.UnitTests;
 /// </summary>
 public sealed class UploaderMapperFieldParityTests
 {
+    /// <summary>A patient the biobank fills in as completely as its export allows.</summary>
+    private static PatientDto FullyPopulatedPatient() => new()
+    {
+        PatientId = "P1",
+        Biobank = "MOU",
+        Consent = true,
+        Sex = "male",
+        BirthYear = 1980,
+        BirthMonth = 4,
+        AccessionNumbers = ["ACC1", "ACC2"],
+        Samples =
+        [
+            new SampleDto
+            {
+                SampleId = "S-T",
+                Type = "tissue",
+                MaterialType = "1",
+                MaterialTypeLabel = "Malignant tumour",
+                EventNumber = 1,
+                CollectionYear = 2020,
+                Biopsy = "2020/2872-1",
+                PredictiveNumber = "2020/1052",
+                SamplesNo = 5,
+                AvailableSamplesNo = 3,
+                AccessionNumbers = ["ACC3"],
+                Diagnosis = "C504",
+                PTnm = "pT1",
+                Morphology = "8500/3",
+                CutTime = new DateTime(2020, 1, 2, 3, 4, 5),
+                FreezeTime = new DateTime(2020, 1, 2, 4, 0, 0),
+                Retrieved = "operational",
+            },
+        ],
+        DiagnosticSpecimens =
+        [
+            new SpecimenDto
+            {
+                SpecimenId = "D-1",
+                SpecimenNumber = 2,
+                Year = 2019,
+                MaterialType = "S",
+                MaterialTypeLabel = "Serum / surgical specimen",
+                Diagnosis = "C777",
+                TakingDate = new DateTime(2019, 3, 4, 5, 6, 7),
+                Retrieved = "unknown",
+            },
+        ],
+    };
+
     [Fact]
     public void PersonalAndClinicalMapEveryField()
     {
-        var patient = PatientMapper.ToPatient(new PatientDto
-        {
-            PatientId = "P1",
-            PersonalIdentifier = "PI",
-            YearOfBirth = 1980,
-            GenderAtBirth = "male",
-            GenderIdentity = "male",
-            ClinicalIdentifier = "CI",
-            BelongsToPerson = "P1",
-            ClinicalDiagnosis = ["C50", "C51"],
-            AgeAtDiagnosis = 40,
-            AgeOfOnset = 38,
-        }).Value;
+        var patient = PatientMapper.ToPatient(FullyPopulatedPatient()).Value;
 
         var personal = patient.Personal!;
-        Assert.Equal("PI", personal.PersonalIdentifier);
+        Assert.Equal("P1", personal.PersonalIdentifier);
         Assert.Equal(1980, personal.YearOfBirth);
         Assert.Equal("male", personal.GenderAtBirth);
-        Assert.Equal("male", personal.GenderIdentity);
+
+        // The biobank records sex, not gender identity.
+        Assert.Null(personal.GenderIdentity);
 
         var clinical = patient.Clinical!;
-        Assert.Equal("CI", clinical.ClinicalIdentifier);
+        Assert.Equal("clinical_P1", clinical.ClinicalIdentifier);
         Assert.Equal("P1", clinical.BelongsToPerson);
-        Assert.Equal(["C50", "C51"], clinical.ClinicalDiagnosis);
-        Assert.Equal(40, clinical.AgeAtDiagnosis);
-        Assert.Equal(38, clinical.AgeOfOnset);
+        Assert.Equal(["C50.4", "C77.7"], clinical.ClinicalDiagnosis);
+        Assert.Equal(39, clinical.AgeAtDiagnosis);
+
+        // Never served: the export has no onset date.
+        Assert.Null(clinical.AgeOfOnset);
     }
 
     [Fact]
     public void MaterialMapsEveryField()
     {
-        var sample = SampleMapper.ToSample(
-            new SampleDto
-            {
-                SampleId = "S1",
-                MaterialIdentifier = "MI",
-                CollectedFromPerson = "P1",
-                BelongsToDiagnosis = ["C50"],
-                SamplingTimestamp = "2020-01-01",
-                RegistrationTimestamp = "2020-01-02",
-                SamplingProtocol = "SP",
-                SamplingProtocolDeviation = "dev",
-                ReasonForSamplingProtocolDeviation = "reason",
-                BiospecimenType = "tissue",
-                AnatomicalSource = "liver",
-                PathologicalState = "tumour",
-                StorageConditions = "-80",
-                ExpirationDate = "2030-01-01",
-                PercentageTumorCells = 12.5,
-                PhysicalLocation = "freezer-1",
-                AnalysesPerformed = ["wgs", "rna"],
-                DerivedFrom = "BLOCK1",
-            },
-            new PatientId("P1")).Value;
+        var dto = FullyPopulatedPatient();
+        var sample = SampleMapper.ToSample(dto.Samples![0], new PatientId("P1"), dto.Biobank).Value;
 
         var m = sample.Material!;
-        Assert.Equal("MI", m.MaterialIdentifier);
+        Assert.Equal("S-T", m.MaterialIdentifier);
         Assert.Equal("P1", m.CollectedFromPerson);
-        Assert.Equal(["C50"], m.BelongsToDiagnosis);
-        Assert.Equal("2020-01-01", m.SamplingTimestamp);
-        Assert.Equal("2020-01-02", m.RegistrationTimestamp);
-        Assert.Equal("SP", m.SamplingProtocol);
-        Assert.Equal("dev", m.SamplingProtocolDeviation);
-        Assert.Equal("reason", m.ReasonForSamplingProtocolDeviation);
-        Assert.Equal("tissue", m.BiospecimenType);
-        Assert.Equal("liver", m.AnatomicalSource);
-        Assert.Equal("tumour", m.PathologicalState);
-        Assert.Equal("-80", m.StorageConditions);
-        Assert.Equal("2030-01-01", m.ExpirationDate);
-        Assert.Equal(12.5, m.PercentageTumorCells);
-        Assert.Equal("freezer-1", m.PhysicalLocation);
-        Assert.Equal(["wgs", "rna"], m.AnalysesPerformed);
-        Assert.Equal("BLOCK1", m.DerivedFrom);
+        Assert.Equal(["clinical_P1"], m.BelongsToDiagnosis);
+        Assert.Equal("2020-01-02T03:04:05", m.SamplingTimestamp);
+        Assert.Equal("2020-01-02T04:00:00", m.RegistrationTimestamp);
+        Assert.Equal("1", m.BiospecimenType);
+        Assert.Equal("MOU", m.PhysicalLocation);
+
+        // Not served by the biobank; filling these is the catalogue mapping's job (#24).
+        Assert.Null(m.SamplingProtocol);
+        Assert.Null(m.SamplingProtocolDeviation);
+        Assert.Null(m.ReasonForSamplingProtocolDeviation);
+        Assert.Null(m.AnatomicalSource);
+        Assert.Null(m.PathologicalState);
+        Assert.Null(m.StorageConditions);
+        Assert.Null(m.ExpirationDate);
+        Assert.Null(m.PercentageTumorCells);
+        Assert.Null(m.AnalysesPerformed);
+        Assert.Null(m.DerivedFrom);
     }
 
     [Fact]

--- a/tests/Uploader.UnitTests/UploaderMapperTests.cs
+++ b/tests/Uploader.UnitTests/UploaderMapperTests.cs
@@ -14,19 +14,97 @@ public sealed class UploaderMapperTests
         var patient = PatientMapper.ToPatient(new PatientDto
         {
             PatientId = "P1",
-            PersonalIdentifier = "P1",
-            YearOfBirth = 1980,
-            ClinicalDiagnosis = ["C50", "C51"],
+            Consent = true,
+            Sex = "male",
+            BirthYear = 1980,
+            Samples =
+            [
+                new SampleDto { SampleId = "S1", Type = "tissue", Diagnosis = "C504" },
+                new SampleDto { SampleId = "S2", Type = "serum", Diagnosis = "C51" },
+            ],
         }).Value;
         var sample = SampleMapper.ToSample(
-            new SampleDto { SampleId = "S1", PercentageTumorCells = 12.5, BiospecimenType = "tissue" },
-            new PatientId("P1")).Value;
+            new SampleDto { SampleId = "S1", Type = "tissue", MaterialType = "1" },
+            new PatientId("P1"),
+            biobank: "MOU").Value;
 
         Assert.Equal("P1", patient.Personal!.PersonalIdentifier);
+        Assert.Equal("male", patient.Personal.GenderAtBirth);
         Assert.Equal(1980, patient.Personal.YearOfBirth);
-        Assert.Equal(["C50", "C51"], patient.Clinical!.ClinicalDiagnosis);
-        Assert.Equal(12.5, sample.Material!.PercentageTumorCells);
-        Assert.Equal("tissue", sample.Material.BiospecimenType);
+        Assert.True(patient.HasConsent);
+        Assert.Equal(["C50.4", "C51"], patient.Clinical!.ClinicalDiagnosis);
+        Assert.Equal("clinical_P1", patient.Clinical.ClinicalIdentifier);
+        Assert.Equal("S1", sample.Material!.MaterialIdentifier);
+        Assert.Equal("1", sample.Material.BiospecimenType);
+        Assert.Equal("MOU", sample.Material.PhysicalLocation);
+    }
+
+    [Fact]
+    public void TissueTakesCutAndFreezeTimesWhileOthersTakeTheTakingDate()
+    {
+        var tissue = SampleMapper.ToSample(
+            new SampleDto
+            {
+                SampleId = "S1",
+                Type = "tissue",
+                CutTime = new DateTime(2020, 1, 2, 3, 4, 5),
+                FreezeTime = new DateTime(2020, 1, 2, 4, 0, 0),
+                TakingDate = new DateTime(1999, 1, 1),
+            },
+            new PatientId("P1")).Value;
+
+        var serum = SampleMapper.ToSample(
+            new SampleDto { SampleId = "S2", Type = "serum", TakingDate = new DateTime(2021, 5, 6, 7, 8, 9) },
+            new PatientId("P1")).Value;
+
+        Assert.Equal("2020-01-02T03:04:05", tissue.Material!.SamplingTimestamp);
+        Assert.Equal("2020-01-02T04:00:00", tissue.Material.RegistrationTimestamp);
+        Assert.Equal("2021-05-06T07:08:09", serum.Material!.SamplingTimestamp);
+        Assert.Equal("2021-05-06T07:08:09", serum.Material.RegistrationTimestamp);
+    }
+
+    [Fact]
+    public void GenomeDiagnosisIsLeftOutWhileSpecimenDiagnosisIsCarried()
+    {
+        var patient = PatientMapper.ToPatient(new PatientDto
+        {
+            PatientId = "P1",
+            Samples =
+            [
+                new SampleDto { SampleId = "S1", Type = "genome", Diagnosis = "C999" },
+                new SampleDto { SampleId = "S2", Type = "tissue", Diagnosis = "C504" },
+                new SampleDto { SampleId = "S3", Type = "serum", Diagnosis = "C504" },
+            ],
+            DiagnosticSpecimens = [new SpecimenDto { SpecimenId = "D1", Diagnosis = "C777" }],
+        }).Value;
+
+        // Duplicates collapse and the order is fixed, so the fingerprint doesn't move with the payload.
+        Assert.Equal(["C50.4", "C77.7"], patient.Clinical!.ClinicalDiagnosis);
+    }
+
+    [Fact]
+    public void AgeAtDiagnosisComesFromTheEarliestSampleEvent()
+    {
+        var patient = PatientMapper.ToPatient(new PatientDto
+        {
+            PatientId = "P1",
+            BirthYear = 1980,
+            BirthMonth = 6,
+            Samples =
+            [
+                new SampleDto { SampleId = "S1", Type = "serum", TakingDate = new DateTime(2021, 5, 6) },
+                new SampleDto
+                {
+                    SampleId = "S2",
+                    Type = "tissue",
+                    FreezeTime = new DateTime(2020, 1, 2),
+                    CutTime = new DateTime(2020, 1, 2),
+                },
+            ],
+        }).Value;
+
+        // Earliest event is 2020-01-02; born 1980-06-01, so the 40th birthday has not happened yet.
+        Assert.Equal(39, patient.Clinical!.AgeAtDiagnosis);
     }
 
     [Fact]
@@ -42,13 +120,15 @@ public sealed class UploaderMapperTests
     public void SampleCarriesTypedReferences()
     {
         var sample = SampleMapper.ToSample(
-            new SampleDto { SampleId = "S1", PredictiveNumber = "PRED1", BiopticNumber = "BIO1" },
+            new SampleDto { SampleId = "S1", PredictiveNumber = "PRED1", Biopsy = "2023/2872-1" },
             new PatientId("P1")).Value;
 
         Assert.Equal(new SampleId("S1"), sample.Id);
         Assert.Equal(new PatientId("P1"), sample.PatientId);
         Assert.Equal(new SequencingId("PRED1"), sample.SequencingId);
-        Assert.Equal(new WsiId("BIO1"), sample.WsiId);
+
+        // The biobank serves no bioptic number; the WSI link waits for #31.
+        Assert.Null(sample.WsiId);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The uploader now consumes the payload `biobank_api` actually serves, carries it into the assembled
patient record, and refuses to upload a patient who has not consented.

## Motivation

`PatientDto` / `SampleDto` were written in FAIR Genomes vocabulary, a shape the biobank API has never
served. Only `patient_id`, `sample_id` and `predictive_number` survived deserialization, so `Personal`,
`Clinical` and `Material` reached the catalogue empty, diagnostic specimens were discarded, and the
consent flag was never read. A sync run would have created correctly linked, entirely blank records.

Closes #20.

## Changes

- **DTOs** reshaped against `PatientResponse` / `SampleResponse` / `SpecimenResponse`. Property names
  mirror those records exactly, so the `SnakeCaseLower` policy both services use lands every field on
  the same wire key without annotations. `bioptic_number` is gone - the biobank never served it.
- **Mapping** fills `Personal`, `Clinical` and `Material` from the biobank's own vocabulary. Values are
  carried as served; three derivations, ported from the previous production uploader, live in
  `BiobankMapping`: the clinical identifier, the ICD-10 dot rule (`C504` -> `C50.4`) and the age between
  birth and the earliest sample event. Tissue takes `cut_time`/`freeze_time`, serum and genome take
  `taking_date`. The diagnosis list is de-duplicated and ordered so the fingerprint does not move with
  the payload order.
- **Consent** is carried onto `PatientAggregate` and required explicitly by
  `PatientCatalogueData.IsUploadEligible`. It used to hold only as a side effect - the biobank refuses to
  attach samples to a non-consenting patient, and a patient without samples was not eligible - which is a
  rule in another service. Consent is permission rather than content, so it stays out of the fingerprint.
- **Sample-level accession numbers** are unioned into the patient's radiology lookup; they share the
  patient-level namespace and were being ignored.
- **Tests**: `BiobankMappingTests` pins the derived values; the mapper tests move to the real payload
  shape and assert both what is mapped and what deliberately stays null; planner and handler tests cover
  consent `false` and unrecorded. On the integration side, a recorded `GET /patients` body is driven
  through the real `HttpSourceDataGateway` into the domain, and `BiobankContractParityTests` compares
  served keys against DTO properties in both directions - so a renamed field fails as one missing key
  plus one orphaned property, and an added field fails as a key with nowhere to go.
- **Docs/skills** record the division that now holds (each source serves its own vocabulary, the uploader
  translates) and the source-contract testing pattern. They still named a single `SourceMapper`, split
  into per-source mappers some time ago.

## Decisions worth reviewing

- **Diagnostic specimens** contribute their diagnosis but no material record: the specimen was consumed
  during diagnosis, so a catalogue material row would advertise material that no longer exists.
- **The WSI link stays empty until #31.** The biobank serves no bioptic number. `biopsy`
  (`2023/2872-1`) is the plausible key - the previous uploader found scans under
  `<year>/<first 2>/<rest>` as `2023_02872-01` - but #31 has not defined that service or its key, so the
  format is recorded in a comment rather than guessed at.
- **Fields dropped deliberately**, each named with its reason on the mapper: `p_tnm`, `morphology`,
  `retrieved`, `event_number`, `collection_year`, `samples_no`, `available_samples_no`,
  `material_type_label`, `biopsy`. No value-object slot, no consumer, and the previous production uploader
  had all of them available and published none.
- **Catalogue vocabulary is out of scope**: no MOLGENIS lookup strings or nullflavors. That shaping
  belongs with the catalogue contract (#24).
- **Commits 1-2 do not build in isolation** - the DTO reshape breaks the old mappers, and the new mappers
  need `HasConsent`. The series builds from `feat(uploader): refuse to upload a patient who has not
  consented` onward. Squash on merge if that matters.

## Verification

`dotnet format --verify-no-changes`, `dotnet build -c Release` and `dotnet test` all pass (442 tests).
The parity guard was checked by temporarily injecting `new_biobank_field` and `tumour_fraction` into the
fixture: both failed, naming the key.

A live end-to-end run is still not possible - it dies on the first patient with an accession number
because the radiology service does not exist (#80/S6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)